### PR TITLE
Anti popping

### DIFF
--- a/src/connector.cpp
+++ b/src/connector.cpp
@@ -13,6 +13,7 @@
 #include <map>
 #include <optional>
 
+#define KXSTUDIO__Reset_none 0
 #define KXSTUDIO__Reset_full 1
 #define KXSTUDIO__Reset_soft 2
 
@@ -1242,9 +1243,6 @@ bool HostConnector::switchScene(const uint8_t scene)
 
     _current.scene = scene;
 
-    // TODO: potentially better to do without fades
-    // and set/flush params without reset()
-    // (requires flush without reset in mod-host?)
     const Host::NonBlockingScopeWithAudioFades hnbs(_host);
 
     for (uint8_t row = 0; row < NUM_BLOCK_CHAIN_ROWS; ++row)
@@ -1278,10 +1276,10 @@ bool HostConnector::switchScene(const uint8_t scene)
                 params.push_back({ paramdata.symbol.c_str(), paramdata.value });
             }
 
-            _host.params_flush(hbp.id, KXSTUDIO__Reset_soft, params.size(), params.data());
+            _host.params_flush(hbp.id, KXSTUDIO__Reset_none, params.size(), params.data());
 
             if (hbp.pair != kMaxHostInstances)
-                _host.params_flush(hbp.pair, KXSTUDIO__Reset_soft, params.size(), params.data());
+                _host.params_flush(hbp.pair, KXSTUDIO__Reset_none, params.size(), params.data());
         }
     }
 

--- a/src/host.cpp
+++ b/src/host.cpp
@@ -1043,6 +1043,7 @@ private:
    #endif
 
     friend class NonBlockingScope;
+    friend class NonBlockingScopeWithAudioFades;
 };
 
 // --------------------------------------------------------------------------------------------------------------------
@@ -1064,6 +1065,26 @@ Host::NonBlockingScope::~NonBlockingScope()
 {
     assert(host.impl->nonBlockingMode);
 
+    host.impl->nonBlockingMode = false;
+    host.impl->wait();
+}
+
+// --------------------------------------------------------------------------------------------------------------------
+
+Host::NonBlockingScopeWithAudioFades::NonBlockingScopeWithAudioFades(Host& host_)
+    : host(host_)
+{
+    assert(! host.impl->nonBlockingMode);
+
+    host.impl->nonBlockingMode = true;
+    host.feature_enable(Host::kFeatureProcessing, Host::kProcessingOffWithFadeOut);
+}
+
+Host::NonBlockingScopeWithAudioFades::~NonBlockingScopeWithAudioFades()
+{
+    assert(host.impl->nonBlockingMode);
+
+    host.feature_enable(Host::kFeatureProcessing, Host::kProcessingOnWithFadeIn);
     host.impl->nonBlockingMode = false;
     host.impl->wait();
 }

--- a/src/host.hpp
+++ b/src/host.hpp
@@ -429,6 +429,20 @@ struct Host {
         ~NonBlockingScope();
     };
 
+   /**
+     * class to activate non-blocking mode during a function scope.
+     * this allows to send a bunch of related messages in quick succession,
+     * while only waiting once (in the class destructor).
+     * This version does audio fade out followed by processing disabling
+     * in the beginning, and at the end processing enabling and fade in.
+     */
+    class NonBlockingScopeWithAudioFades {
+        Host& host;
+    public:
+        NonBlockingScopeWithAudioFades(Host& host);
+        ~NonBlockingScopeWithAudioFades();
+    };
+
 private:
     struct Impl;
     Impl* const impl;


### PR DESCRIPTION
Use NonBlockingScopeWithAudioFades for all cases that need fade out and fade in for smooth transitions.

Add fadeout+fadein for replaceBlock, reorderBlock, switchScene (because it's using params_flush which does reset on plugin params, if it didn't, fades might be unnecessary)