### PR TITLE
Preset loading fixes

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -53,8 +53,10 @@ jobs:
         env:
           LV2_PATH: $GITHUB_WORKSPACE/test-blocks/build/
         run: |
+          mkdir test-presets
           echo $(which jackd) ${{ env.JACKD_CMD_ARGS }} | tee ~/.jackdrc
           ./build/tests
+          rm -rf test-presets
 
   # macos:
   #   runs-on: macos-15
@@ -91,5 +93,7 @@ jobs:
   #       env:
   #         LV2_PATH: $GITHUB_WORKSPACE/test-blocks/build/
   #       run: |
+  #         mkdir test-presets
   #         echo $(which jackd) ${{ env.JACKD_CMD_ARGS }} | tee ~/.jackdrc
   #         ./build/tests
+  #         rm -rf test-presets

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -53,10 +53,8 @@ jobs:
         env:
           LV2_PATH: $GITHUB_WORKSPACE/test-blocks/build/
         run: |
-          mkdir test-presets
           echo $(which jackd) ${{ env.JACKD_CMD_ARGS }} | tee ~/.jackdrc
           ./build/tests
-          rm -rf test-presets
 
   # macos:
   #   runs-on: macos-15

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+cd $(dirname "${0}")
+
 JACKD_CMD_ARGS="-r -d dummy -r 48000 -p 8192"
 
 # build test blocks
@@ -10,13 +12,11 @@ export LV2_PATH=$(pwd)/test-blocks/build/
 cmake -S . -B build -DCMAKE_BUILD_TYPE=Debug
 cmake --build build -j
 
-# temp directory for preset files
-mkdir test-presets
-
 # run tests
 echo $(which jackd) $JACKD_CMD_ARGS | tee ~/.jackdrc
 ./build/tests
 
+# cleanup (in case of failure or crash)
 rm -rf test-presets
 
 killall -SIGKILL jackd || true

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -10,6 +10,11 @@ export LV2_PATH=$(pwd)/test-blocks/build/
 cmake -S . -B build -DCMAKE_BUILD_TYPE=Debug
 cmake --build build -j
 
+# temp directory for preset files
+mkdir test-presets
+
 # run tests
 echo $(which jackd) $JACKD_CMD_ARGS | tee ~/.jackdrc
 ./build/tests
+
+rm -rf test-presets

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -18,3 +18,5 @@ echo $(which jackd) $JACKD_CMD_ARGS | tee ~/.jackdrc
 ./build/tests
 
 rm -rf test-presets
+
+killall -SIGKILL jackd || true

--- a/src/connector.cpp
+++ b/src/connector.cpp
@@ -1369,10 +1369,7 @@ bool HostConnector::replaceBlock(const uint8_t row, const uint8_t block, const c
                 hostBypassBlockPair(hbp, false);
             }
 
-            _host.params_flush(hbp.id, LV2_KXSTUDIO_PROPERTIES_RESET_FULL, params.size(), params.data());
-
-            if (hbp.pair != kMaxHostInstances)
-                _host.params_flush(hbp.pair, LV2_KXSTUDIO_PROPERTIES_RESET_FULL, params.size(), params.data());
+            hostParamsFlushBlockPair(hbp, LV2_KXSTUDIO_PROPERTIES_RESET_FULL, params);
 
             for (uint8_t p = 0; p < MAX_PARAMS_PER_BLOCK; ++p)
             {
@@ -1387,10 +1384,7 @@ bool HostConnector::replaceBlock(const uint8_t row, const uint8_t block, const c
                 if (propdata.value != propdata.meta.defpath)
                 {
                     propdata.value = propdata.meta.defpath;
-                    _host.patch_set(hbp.id, propdata.uri.c_str(), propdata.value.c_str());
-
-                    if (hbp.pair != kMaxHostInstances)
-                        _host.patch_set(hbp.pair, propdata.uri.c_str(), propdata.value.c_str());
+                    hostPatchSetBlockPair(hbp, propdata);
                 }
             }
         }
@@ -1683,11 +1677,8 @@ bool HostConnector::replaceBlockWhileKeepingCurrentData(const uint8_t row, const
             hostBypassBlockPair(hbp, true);
         }
 
-        _host.params_flush(hbp.id, LV2_KXSTUDIO_PROPERTIES_RESET_FULL, params.size(), params.data());
-
-        if (hbp.pair != kMaxHostInstances)
-            _host.params_flush(hbp.pair, LV2_KXSTUDIO_PROPERTIES_RESET_FULL, params.size(), params.data());
-
+        hostParamsFlushBlockPair(hbp, LV2_KXSTUDIO_PROPERTIES_RESET_FULL, params);
+        
         for (uint8_t p = 0; p < MAX_PARAMS_PER_BLOCK; ++p)
         {
             const Property& propdata(blockcopy.properties[p]);
@@ -1697,12 +1688,7 @@ bool HostConnector::replaceBlockWhileKeepingCurrentData(const uint8_t row, const
                 continue;
 
             if (propdata.value != propdata.meta.defpath)
-            {
-                _host.patch_set(hbp.id, propdata.uri.c_str(), propdata.value.c_str());
-
-                if (hbp.pair != kMaxHostInstances)
-                    _host.patch_set(hbp.pair, propdata.uri.c_str(), propdata.value.c_str());
-            }
+                hostPatchSetBlockPair(hbp, propdata);
         }
     }
 
@@ -2098,17 +2084,11 @@ bool HostConnector::switchScene(const uint8_t scene)
 
                 propdata.value = sceneValues.properties[p];
 
-                _host.patch_set(hbp.id, propdata.uri.c_str(), propdata.value.c_str());
-
-                if (hbp.pair != kMaxHostInstances)
-                    _host.patch_set(hbp.pair, propdata.uri.c_str(), propdata.value.c_str());
+                hostPatchSetBlockPair(hbp, propdata);
             }
 
-            _host.params_flush(hbp.id, LV2_KXSTUDIO_PROPERTIES_RESET_NONE, params.size(), params.data());
-
-            if (hbp.pair != kMaxHostInstances)
-                _host.params_flush(hbp.pair, LV2_KXSTUDIO_PROPERTIES_RESET_NONE, params.size(), params.data());
-
+            hostParamsFlushBlockPair(hbp, LV2_KXSTUDIO_PROPERTIES_RESET_NONE, params);
+            
             // unbypass/enable last if relevant
             if (blockdata.meta.enable.hasScenes && blockdata.sceneValues[_current.scene].enabled)
             {
@@ -2934,10 +2914,7 @@ void HostConnector::setBlockProperty(const uint8_t row,
 
     propdata.value = value;
 
-    _host.patch_set(hbp.id, propdata.uri.c_str(), value);
-
-    if (hbp.pair != kMaxHostInstances)
-        _host.patch_set(hbp.pair, propdata.uri.c_str(), value);
+    hostPatchSetBlockPair(hbp, propdata);
 }
 
 // --------------------------------------------------------------------------------------------------------------------
@@ -4994,17 +4971,11 @@ void HostConnector::hostSwitchPreset(const Current& prev)
                         if (defpropdata.value == prevpropdata.value)
                             continue;
 
-                        _host.patch_set(hbp.id, defpropdata.uri.c_str(), defpropdata.value.c_str());
-
-                        if (hbp.pair != kMaxHostInstances)
-                            _host.patch_set(hbp.pair, defpropdata.uri.c_str(), defpropdata.value.c_str());
+                        hostPatchSetBlockPair(hbp, defpropdata);
                     }
 
-                    _host.params_flush(hbp.id, LV2_KXSTUDIO_PROPERTIES_RESET_FULL, params.size(), params.data());
-
-                    if (hbp.pair != kMaxHostInstances)
-                        _host.params_flush(hbp.pair, LV2_KXSTUDIO_PROPERTIES_RESET_FULL, params.size(), params.data());
-
+                    hostParamsFlushBlockPair(hbp, LV2_KXSTUDIO_PROPERTIES_RESET_FULL, params);
+                    
                     continue;
                 }
 
@@ -5054,16 +5025,10 @@ void HostConnector::hostSwitchPreset(const Current& prev)
                     if (defpropdata.value == defpropdata.meta.defpath)
                         continue;
 
-                    _host.patch_set(hbp.id, defpropdata.uri.c_str(), defpropdata.value.c_str());
-
-                    if (hbp.pair != kMaxHostInstances)
-                        _host.patch_set(hbp.pair, defpropdata.uri.c_str(), defpropdata.value.c_str());
+                    hostPatchSetBlockPair(hbp, defpropdata);
                 }
 
-                _host.params_flush(hbp.id, LV2_KXSTUDIO_PROPERTIES_RESET_FULL, params.size(), params.data());
-
-                if (hbp.pair != kMaxHostInstances)
-                    _host.params_flush(hbp.pair, LV2_KXSTUDIO_PROPERTIES_RESET_FULL, params.size(), params.data());
+                hostParamsFlushBlockPair(hbp, LV2_KXSTUDIO_PROPERTIES_RESET_FULL, params);
             }
         }
         // ensure necessary dual mono blocks are added
@@ -5126,6 +5091,26 @@ void HostConnector::hostRemoveBlockPair(const HostBlockPair& hbp)
 
     if (hbp.pair != kMaxHostInstances)
         _host.remove(hbp.pair);
+}
+
+// --------------------------------------------------------------------------------------------------------------------
+
+void HostConnector::hostPatchSetBlockPair(const HostBlockPair& hbp, const Property& propdata)
+{
+    _host.patch_set(hbp.id, propdata.uri.c_str(), propdata.value.c_str());
+
+    if (hbp.pair != kMaxHostInstances)
+        _host.patch_set(hbp.pair, propdata.uri.c_str(), propdata.value.c_str());
+}
+
+// --------------------------------------------------------------------------------------------------------------------
+
+void HostConnector::hostParamsFlushBlockPair(const HostBlockPair& hbp, const uint8_t reset_value, const std::vector<flushed_param>& params)
+{
+    _host.params_flush(hbp.id, reset_value, params.size(), params.data());
+
+    if (hbp.pair != kMaxHostInstances)
+        _host.params_flush(hbp.pair, reset_value, params.size(), params.data());
 }
 
 // --------------------------------------------------------------------------------------------------------------------

--- a/src/connector.cpp
+++ b/src/connector.cpp
@@ -4780,10 +4780,8 @@ void HostConnector::hostLoadPreset(const uint8_t preset)
         const ChainRow& chaindata(active ? _current.chains[row] : _presets[preset].chains[row]);
 
         bool firstBlock = true;
-        // bool previousPluginStereoOut;
 
         // related to active preset only
-        // uint8_t last = 0;
         uint8_t numLoadedPlugins = 0;
 
         for (uint8_t bl = 0; bl < NUM_BLOCKS_PER_PRESET; ++bl)
@@ -4793,10 +4791,7 @@ void HostConnector::hostLoadPreset(const uint8_t preset)
                 continue;
 
             if (firstBlock)
-            {
                 firstBlock = false;
-                // previousPluginStereoOut = chaindata.capture[0] != chaindata.capture[1];
-            }
 
             const auto loadInstance = [=, &blockdata](const uint16_t instance)
             {
@@ -4832,24 +4827,9 @@ void HostConnector::hostLoadPreset(const uint8_t preset)
                 return false;
             };
 
-            // const bool dualmono = previousPluginStereoOut && blockdata.meta.numInputs == 1;
             const HostBlockPair hbp = { _mapper.add(preset, row, bl), kMaxHostInstances };
 
             bool added = loadInstance(hbp.id);
-
-            // if (added)
-            // {
-            //     if (dualmono)
-            //     {
-            //         const uint16_t pair = _mapper.add_pair(preset, row, bl);
-
-            //         if (! loadInstance(pair))
-            //         {
-            //             added = false;
-            //             _host.remove(hbp.pair);
-            //         }
-            //     }
-            // }
 
             if (! added)
             {
@@ -4860,32 +4840,15 @@ void HostConnector::hostLoadPreset(const uint8_t preset)
                 continue;
             }
 
-            // previousPluginStereoOut = blockdata.meta.numOutputs == 2 || dualmono;
-
             // dealing with connections after this point, only valid if preset is the active one
             if (active)
-            {
                 numLoadedPlugins++;
-                // if (++numLoadedPlugins == 1)
-            //         hostConnectBlockToChainInput(row, bl);
-            //     else
-            //         hostConnectBlockToBlock(row, last, bl);
 
-                // hostSetupSideIO(row, bl, hbp, nullptr);
-                // last = bl;
-            }
             hostSetupSideIO(preset, row, bl, hbp, nullptr);
         }
 
         if (active)
-        {
-            // if (numLoadedPlugins != 0)
-            //     hostConnectBlockToChainOutput(row, last);
-            // else if (!_current.chains[row].capture[0].empty())
-            //     hostConnectChainEndpoints(row);
-
             _current.numLoadedPlugins += numLoadedPlugins;
-        }
     }
 
     // add necessary dual mono pairs

--- a/src/connector.cpp
+++ b/src/connector.cpp
@@ -867,11 +867,7 @@ bool HostConnector::preloadPresetFromFile(const uint8_t preset, const char* cons
 
                 const HostBlockPair hbp = _mapper.remove(preset, row, bl);
 
-                if (hbp.id != kMaxHostInstances)
-                    _host.remove(hbp.id);
-
-                if (hbp.pair != kMaxHostInstances)
-                    _host.remove(hbp.pair);
+                hostRemoveBlockPair(hbp);
             }
         }
     }
@@ -3639,11 +3635,7 @@ void HostConnector::hostRemoveInstanceForBlock(const uint8_t row, const uint8_t 
 
     const HostBlockPair hbp = _mapper.remove(_current.preset, row, block);
 
-    if (hbp.id != kMaxHostInstances)
-        _host.remove(hbp.id);
-
-    if (hbp.pair != kMaxHostInstances)
-        _host.remove(hbp.pair);
+    hostRemoveBlockPair(hbp);
 
    #if NUM_BLOCK_CHAIN_ROWS != 1
     if (row == 0)
@@ -5021,11 +5013,7 @@ void HostConnector::hostSwitchPreset(const Current& prev)
                 {
                     const HostBlockPair hbp = _mapper.remove(prev.preset, row, bl);
 
-                    if (hbp.id != kMaxHostInstances)
-                        _host.remove(hbp.id);
-
-                    if (hbp.pair != kMaxHostInstances)
-                        _host.remove(hbp.pair);
+                    hostRemoveBlockPair(hbp);
                 }
 
                 // nothing else to do if block is empty
@@ -5127,6 +5115,17 @@ void HostConnector::hostBypassBlockPair(const HostBlockPair& hbp, const bool byp
 
     if (hbp.pair != kMaxHostInstances)
         _host.bypass(hbp.pair, bypass);
+}
+
+// --------------------------------------------------------------------------------------------------------------------
+
+void HostConnector::hostRemoveBlockPair(const HostBlockPair& hbp)
+{
+    if (hbp.id != kMaxHostInstances)
+        _host.remove(hbp.id);
+
+    if (hbp.pair != kMaxHostInstances)
+        _host.remove(hbp.pair);
 }
 
 // --------------------------------------------------------------------------------------------------------------------

--- a/src/connector.cpp
+++ b/src/connector.cpp
@@ -1175,10 +1175,7 @@ bool HostConnector::enableBlock(const uint8_t row, const uint8_t block, const bo
     blockdata.enabled = enable;
     blockdata.sceneValues[_current.scene].enabled = enable;
 
-    _host.bypass(hbp.id, !enable);
-
-    if (hbp.pair != kMaxHostInstances)
-        _host.bypass(hbp.pair, !enable);
+    hostBypassBlockPair(hbp, !enable);
 
     return true;
 }
@@ -1373,10 +1370,7 @@ bool HostConnector::replaceBlock(const uint8_t row, const uint8_t block, const c
             {
                 blockdata.enabled = true;
 
-                _host.bypass(hbp.id, false);
-
-                if (hbp.pair != kMaxHostInstances)
-                    _host.bypass(hbp.pair, false);
+                hostBypassBlockPair(hbp, false);
             }
 
             _host.params_flush(hbp.id, LV2_KXSTUDIO_PROPERTIES_RESET_FULL, params.size(), params.data());
@@ -1690,10 +1684,7 @@ bool HostConnector::replaceBlockWhileKeepingCurrentData(const uint8_t row, const
 
         if (!blockcopy.enabled)
         {
-            _host.bypass(hbp.id, true);
-
-            if (hbp.pair != kMaxHostInstances)
-                _host.bypass(hbp.pair, true);
+            hostBypassBlockPair(hbp, true);
         }
 
         _host.params_flush(hbp.id, LV2_KXSTUDIO_PROPERTIES_RESET_FULL, params.size(), params.data());
@@ -2085,10 +2076,7 @@ bool HostConnector::switchScene(const uint8_t scene)
             if (blockdata.meta.enable.hasScenes && !sceneValues.enabled)
             {
                 blockdata.enabled = false;
-                _host.bypass(hbp.id, true);
-
-                if (hbp.pair != kMaxHostInstances)
-                    _host.bypass(hbp.pair, true);
+                hostBypassBlockPair(hbp, true);
             }
 
             for (uint8_t p = 0; p < MAX_PARAMS_PER_BLOCK; ++p)
@@ -2129,10 +2117,7 @@ bool HostConnector::switchScene(const uint8_t scene)
             if (blockdata.meta.enable.hasScenes && blockdata.sceneValues[_current.scene].enabled)
             {
                 blockdata.enabled = true;
-                _host.bypass(hbp.id, false);
-
-                if (hbp.pair != kMaxHostInstances)
-                    _host.bypass(hbp.pair, false);
+                hostBypassBlockPair(hbp, false);
             }
         }
     }
@@ -4985,10 +4970,7 @@ void HostConnector::hostSwitchPreset(const Current& prev)
 
                     if (defblockdata.enabled != prevblockdata.enabled)
                     {
-                        _host.bypass(hbp.id, !defblockdata.enabled);
-
-                        if (hbp.pair != kMaxHostInstances)
-                            _host.bypass(hbp.pair, !defblockdata.enabled);
+                        hostBypassBlockPair(hbp, !defblockdata.enabled);
                     }
 
                     params.clear();
@@ -5056,10 +5038,7 @@ void HostConnector::hostSwitchPreset(const Current& prev)
 
                 if (!defblockdata.enabled)
                 {
-                    _host.bypass(hbp.id, true);
-
-                    if (hbp.pair != kMaxHostInstances)
-                        _host.bypass(hbp.pair, true);
+                    hostBypassBlockPair(hbp, true);
                 }
 
                 params.clear();
@@ -5138,6 +5117,16 @@ bool HostConnector::hostLoadInstance(const Block& blockdata, const uint16_t inst
     }
 
     return false;
+}
+
+// --------------------------------------------------------------------------------------------------------------------
+
+void HostConnector::hostBypassBlockPair(const HostBlockPair& hbp, const bool bypass)
+{
+    _host.bypass(hbp.id, bypass);
+
+    if (hbp.pair != kMaxHostInstances)
+        _host.bypass(hbp.pair, bypass);
 }
 
 // --------------------------------------------------------------------------------------------------------------------

--- a/src/connector.cpp
+++ b/src/connector.cpp
@@ -5049,13 +5049,6 @@ void HostConnector::hostSwitchPreset(const Current& prev)
                 HostBlockPair hbp = { _mapper.add(prev.preset, row, bl), kMaxHostInstances };
                 _host.preload(defblockdata.uri.c_str(), hbp.id);
 
-                if (shouldBlockBeStereo(defaults.chains[row], bl) && 
-                    defblockdata.meta.numInputs == 1)
-                {
-                    hbp.pair = _mapper.add_pair(prev.preset, row, bl);
-                    _host.preload(defblockdata.uri.c_str(), hbp.pair);
-                }
-
                 if (!defblockdata.enabled)
                 {
                     _host.bypass(hbp.id, true);

--- a/src/connector.cpp
+++ b/src/connector.cpp
@@ -3354,7 +3354,8 @@ void HostConnector::hostEnsureStereoChain(const uint8_t preset, const uint8_t ro
         {
             const uint16_t pair = _mapper.add_pair(preset, row, bl);
 
-            if (_host.add(blockdata.uri.c_str(), pair))
+            if (active ? _host.add(blockdata.uri.c_str(), pair)
+                       : _host.preload(blockdata.uri.c_str(), pair))
             {
                 if (!blockdata.enabled)
                     _host.bypass(pair, true);
@@ -5048,7 +5049,8 @@ void HostConnector::hostSwitchPreset(const Current& prev)
                 HostBlockPair hbp = { _mapper.add(prev.preset, row, bl), kMaxHostInstances };
                 _host.preload(defblockdata.uri.c_str(), hbp.id);
 
-                if (shouldBlockBeStereo(defaults.chains[row], bl))
+                if (shouldBlockBeStereo(defaults.chains[row], bl) && 
+                    defblockdata.meta.numInputs == 1)
                 {
                     hbp.pair = _mapper.add_pair(prev.preset, row, bl);
                     _host.preload(defblockdata.uri.c_str(), hbp.pair);
@@ -5099,6 +5101,8 @@ void HostConnector::hostSwitchPreset(const Current& prev)
                     _host.params_flush(hbp.pair, LV2_KXSTUDIO_PROPERTIES_RESET_FULL, params.size(), params.data());
             }
         }
+        // ensure necessary dual mono blocks are added
+        hostEnsureStereoChain(prev.preset, 0, 0);
     }
 }
 

--- a/src/connector.cpp
+++ b/src/connector.cpp
@@ -1462,39 +1462,12 @@ bool HostConnector::replaceBlock(const uint8_t row, const uint8_t block, const c
             hostRemoveInstanceForBlock(row, block);
         }
 
-        // activate dual mono if previous plugin is stereo or also dualmono
-        bool dualmono = false;
-        if (numInputs == 1) {
-            dualmono = shouldBlockBeStereo(chaindata, block);
-            if ((numSideInputs != 0) && 
-                !dualmono && 
-                (row + 1 < NUM_BLOCK_CHAIN_ROWS)) {
-                // if dual mono wasn't enforced by current row, it might be enforced by next row
-                ChainRow& chain2data(_current.chains[row + 1]);
-                dualmono = shouldBlockBeStereo(chain2data, NUM_BLOCKS_PER_PRESET);
-            }
-        }
-
         HostBlockPair hbp = { _mapper.add(_current.preset, row, block), kMaxHostInstances };
 
         bool added = _host.add(uri, hbp.id);
         if (added)
         {
             mod_log_debug("block %u loaded plugin %s", block, uri);
-
-            if (dualmono)
-            {
-                hbp.pair = _mapper.add_pair(_current.preset, row, block);
-
-                if (! _host.add(uri, hbp.pair))
-                {
-                    mod_log_warn("block %u failed to load dual-mono plugin %s: %s",
-                                 block, uri, _host.last_error.c_str());
-
-                    added = false;
-                    _host.remove(hbp.id);
-                }
-            }
         }
         else
         {

--- a/src/connector.hpp
+++ b/src/connector.hpp
@@ -657,7 +657,7 @@ protected:
     void hostDisconnectAllBlockOutputs(const Block& blockdata, const HostBlockPair& hbp, bool disconnectSideChains = false);
     void hostDisconnectChainEndpoints(uint8_t row);
 
-    void hostEnsureStereoChain(uint8_t preset, uint8_t row, uint8_t blockStart, bool recursive = false);
+    void hostEnsureStereoChain(uint8_t preset, uint8_t row, uint8_t blockStart = 0, bool recursive = false);
 
     void hostSetupSideIO(uint8_t preset, uint8_t row, uint8_t block, HostBlockPair hbp, const Lv2Plugin* plugin);
 

--- a/src/connector.hpp
+++ b/src/connector.hpp
@@ -647,9 +647,9 @@ protected:
     void hostDisconnectAllBlockOutputs(const Block& blockdata, const HostBlockPair& hbp, bool disconnectSideChains = false);
     void hostDisconnectChainEndpoints(uint8_t row);
 
-    void hostEnsureStereoChain(uint8_t row, uint8_t blockStart, bool recursive = false);
+    void hostEnsureStereoChain(uint8_t preset, uint8_t row, uint8_t blockStart, bool recursive = false);
 
-    void hostSetupSideIO(uint8_t row, uint8_t block, HostBlockPair hbp, const Lv2Plugin* plugin);
+    void hostSetupSideIO(uint8_t preset, uint8_t row, uint8_t block, HostBlockPair hbp, const Lv2Plugin* plugin);
 
     // remove all bindings related to a block
     void hostRemoveAllBlockBindings(uint8_t row, uint8_t block);

--- a/src/connector.hpp
+++ b/src/connector.hpp
@@ -692,6 +692,9 @@ private:
     // set bypass state of block and its pair if exists
     void hostBypassBlockPair(const HostBlockPair& hbp, bool bypass);
 
+    // set bypass state of block and its pair if exists
+    void hostRemoveBlockPair(const HostBlockPair& hbp);
+
     // internal feedback handling, for updating parameter values
     void hostFeedbackCallback(const HostFeedbackData& data) override;
 

--- a/src/connector.hpp
+++ b/src/connector.hpp
@@ -689,6 +689,9 @@ private:
     // add (active==true) or preload block defined by blockdata to instance_number
     bool hostLoadInstance(const Block& blockdata, uint16_t instance_number, bool active);
 
+    // set bypass state of block and its pair if exists
+    void hostBypassBlockPair(const HostBlockPair& hbp, bool bypass);
+
     // internal feedback handling, for updating parameter values
     void hostFeedbackCallback(const HostFeedbackData& data) override;
 

--- a/src/connector.hpp
+++ b/src/connector.hpp
@@ -692,8 +692,14 @@ private:
     // set bypass state of block and its pair if exists
     void hostBypassBlockPair(const HostBlockPair& hbp, bool bypass);
 
-    // set bypass state of block and its pair if exists
+    // remove block instance and its pair if exists
     void hostRemoveBlockPair(const HostBlockPair& hbp);
+
+    // patch_set for block and its pair if exists
+    void hostPatchSetBlockPair(const HostBlockPair& hbp, const Property& propdata);
+
+    // params_flush for block and its pair if exists
+    void hostParamsFlushBlockPair(const HostBlockPair& hbp, uint8_t reset_value, const std::vector<flushed_param>& params);
 
     // internal feedback handling, for updating parameter values
     void hostFeedbackCallback(const HostFeedbackData& data) override;

--- a/src/connector.hpp
+++ b/src/connector.hpp
@@ -686,6 +686,9 @@ private:
     // unload "old" and load current preset, only does host commands
     void hostSwitchPreset(const Current& old);
 
+    // add (active==true) or preload block defined by blockdata to instance_number
+    bool hostLoadInstance(const Block& blockdata, uint16_t instance_number, bool active);
+
     // internal feedback handling, for updating parameter values
     void hostFeedbackCallback(const HostFeedbackData& data) override;
 

--- a/src/tests.cpp
+++ b/src/tests.cpp
@@ -8,7 +8,7 @@
 #define SIDEOUTBLOCK "urn:mod-connector:testsideout"
 #define SIDEINBLOCK "urn:mod-connector:testsidein"
 
-#define PRESETFILEPATH "./test-presets/"
+#define PRESETFILEPATH "./test-presets"
 
 #include "connector.hpp"
 #include "utils.hpp"
@@ -38,6 +38,7 @@ constexpr const char* getProcessErrorAsString(QProcess::ProcessError error)
         return "Unkown error";
     }
 }
+
 class HostProcess : public QProcess
 {
     bool closing = false;
@@ -352,8 +353,7 @@ class HostConnectorTests : public QObject
         assert_return(testNoPassthrough(), false);
 
         // save preset state to file
-        std::string presetFileName = format("%s/testSingleMonoChain.json", PRESETFILEPATH);
-        assert_return(connector.saveCurrentPresetToFile(presetFileName.c_str()), false);
+        assert_return(connector.saveCurrentPresetToFile(PRESETFILEPATH "/testSingleMonoChain.json"), false);
 
         // remove plugin from end
         assert_return(connector.replaceBlock(0, 5, nullptr), false);
@@ -408,7 +408,7 @@ class HostConnectorTests : public QObject
 
         // test loading from file
         const std::array<std::string, NUM_PRESETS_PER_BANK> bankPresets = {
-            presetFileName,
+            PRESETFILEPATH "/testSingleMonoChain.json",
             {},
             {},
         };
@@ -550,8 +550,7 @@ class HostConnectorTests : public QObject
         // basic dual mono to stereo OK
 
         // save preset state to file
-        std::string presetFileName = format("%s/testSingleStereoChain.json", PRESETFILEPATH);
-        assert_return(connector.saveCurrentPresetToFile(presetFileName.c_str()), false);
+        assert_return(connector.saveCurrentPresetToFile(PRESETFILEPATH "/testSingleStereoChain.json"), false);
 
         // move mono block from beginning to end
         // chain becomes: stereo - stereo - dual mono - dual mono - stereo - dual mono
@@ -753,7 +752,7 @@ class HostConnectorTests : public QObject
 
         // test loading from file
         const std::array<std::string, NUM_PRESETS_PER_BANK> bankPresets = {
-            presetFileName,
+            PRESETFILEPATH "/testSingleStereoChain.json",
             {},
             {},
         };
@@ -850,8 +849,7 @@ class HostConnectorTests : public QObject
         assert_return(testNoPassthrough(), false);
 
         // save preset state to file
-        std::string presetFileName1 = format("%s/testSideChainBuiltInOrder1.json", PRESETFILEPATH);
-        assert_return(connector.saveCurrentPresetToFile(presetFileName1.c_str()), false);
+        assert_return(connector.saveCurrentPresetToFile(PRESETFILEPATH "/testSideChainBuiltInOrder1.json"), false);
 
         // remove sidein block (undo sidechain ending)
         assert_return(connector.replaceBlock(0, 4, nullptr), false);
@@ -948,8 +946,7 @@ class HostConnectorTests : public QObject
         assert_return(testNoPassthrough(), false);
 
         // save preset state to file
-        std::string presetFileName2 = format("%s/testSideChainBuiltInOrder2.json", PRESETFILEPATH);
-        assert_return(connector.saveCurrentPresetToFile(presetFileName2.c_str()), false);
+        assert_return(connector.saveCurrentPresetToFile(PRESETFILEPATH "/testSideChainBuiltInOrder2.json"), false);
 
         // remove sidein block (undo sidechain ending)
         assert_return(connector.replaceBlock(0, 4, nullptr), false);
@@ -1051,8 +1048,7 @@ class HostConnectorTests : public QObject
         assert_return(testNoPassthrough(), false);
 
         // save preset state to file
-        std::string presetFileName3 = format("%s/testSideChainBuiltInOrder3.json", PRESETFILEPATH);
-        assert_return(connector.saveCurrentPresetToFile(presetFileName3.c_str()), false);
+        assert_return(connector.saveCurrentPresetToFile(PRESETFILEPATH "/testSideChainBuiltInOrder3.json"), false);
 
         // remove sidechain completion
         assert_return(connector.replaceBlock(0, 4, nullptr), false);
@@ -1110,9 +1106,9 @@ class HostConnectorTests : public QObject
         // ***** test loading all previously saved presets from file
 
         const std::array<std::string, NUM_PRESETS_PER_BANK> bankPresets = {
-            presetFileName1,
-            presetFileName2,
-            presetFileName3,
+            PRESETFILEPATH "/testSideChainBuiltInOrder1.json",
+            PRESETFILEPATH "/testSideChainBuiltInOrder2.json",
+            PRESETFILEPATH "/testSideChainBuiltInOrder3.json",
         };
         connector.loadBankFromPresetFiles(bankPresets, 0);
 
@@ -1361,8 +1357,7 @@ class HostConnectorTests : public QObject
         assert_return(testNoPassthrough(), false);
 
         // save preset state to file
-        std::string presetFileName1 = format("%s/testSideChainMoveStereoOnFirstRow1.json", PRESETFILEPATH);
-        assert_return(connector.saveCurrentPresetToFile(presetFileName1.c_str()), false);
+        assert_return(connector.saveCurrentPresetToFile(PRESETFILEPATH "/testSideChainMoveStereoOnFirstRow1.json"), false);
 
         // move stereo block back inside sidechaining blocks on row 0
         // SIDEOUTBLOCK 2 becomes block 1
@@ -1436,7 +1431,7 @@ class HostConnectorTests : public QObject
 
         // test loading from file
         const std::array<std::string, NUM_PRESETS_PER_BANK> bankPresets = {
-            presetFileName1,
+            PRESETFILEPATH "/testSideChainMoveStereoOnFirstRow1.json",
             {},
             {},
         };
@@ -1672,8 +1667,17 @@ public:
         : client(c),
           hostProcess(hostProc)
     {
+        QDir::current().mkdir(PRESETFILEPATH);
+
         mod_log_info("Connecting to host...");
         QTimer::singleShot(100, this, &HostConnectorTests::reconnect);
+    }
+
+    ~HostConnectorTests() override
+    {
+        QDir dir(QDir::current());
+        if (dir.cd(PRESETFILEPATH))
+            dir.removeRecursively();
     }
 };
 

--- a/src/tests.cpp
+++ b/src/tests.cpp
@@ -698,6 +698,8 @@ class HostConnectorTests : public QObject
         // remove remaining block
         assert_return(connector.replaceBlock(0, 2, nullptr), false);
 
+        assert_return(testPassthrough(), false);
+
         // test loading from file
         const std::array<std::string, NUM_PRESETS_PER_BANK> bankPresets = {
             presetFileName,
@@ -915,6 +917,10 @@ class HostConnectorTests : public QObject
         assert_return(checkOnlyConnectionBothWays(blockPortOut2(1, 2), blockPairPortIn2(0, 4)), false);
         assert_return(testNoPassthrough(), false);
 
+        // save preset state to file
+        std::string presetFileName3 = format("%s/testSideChainBuiltInOrder3.json", PRESETFILEPATH);
+        assert_return(connector.saveCurrentPresetToFile(presetFileName3.c_str()), false);
+
         // remove sidechain completion
         assert_return(connector.replaceBlock(0, 4, nullptr), false);
         // row 0
@@ -937,11 +943,13 @@ class HostConnectorTests : public QObject
         assert_return(connector.replaceBlock(0, 2, nullptr), false);
         assert_return(connector.replaceBlock(0, 1, nullptr), false);
 
+        assert_return(testPassthrough(), false);
+
         // test loading from file
         const std::array<std::string, NUM_PRESETS_PER_BANK> bankPresets = {
             presetFileName1,
             presetFileName2,
-            {},
+            presetFileName3,
         };
         connector.loadBankFromPresetFiles(bankPresets, 0);
 
@@ -978,6 +986,26 @@ class HostConnectorTests : public QObject
         assert_return(checkOnly2Connections(blockPortOut2(0, 1), blockPortIn2(0, 4), blockPairPortIn2(0, 4)), false);
         assert_return(checkOnlyConnection(blockPortIn2(0, 4), blockPortOut2(0, 1)), false);
         assert_return(checkOnlyConnection(blockPairPortIn2(0, 4), blockPortOut2(0, 1)), false);
+        assert_return(testNoPassthrough(), false);
+
+        // file 3: switch to preset
+        assert_return(connector.switchPreset(2), false);
+        // file 3: check connections are the same as before saving the file
+        // row 0 connections
+        assert_return(checkOnlyConnection(blockPortIn1(0, 1), JACK_CAPTURE_PORT_1), false);
+        assert_return(checkOnly2Connections(blockPortOut1(0, 1), blockPortIn1(0, 2), blockPortIn2(0, 2)), false);
+        assert_return(checkOnlyConnection(blockPortIn1(0, 2), blockPortOut1(0, 1)), false);
+        assert_return(checkOnlyConnection(blockPortIn2(0, 2), blockPortOut1(0, 1)), false);
+        assert_return(checkOnlyConnectionBothWays(blockPortOut1(0, 2), blockPortIn1(0, 4)), false);
+        assert_return(checkOnlyConnectionBothWays(blockPortOut2(0, 2), blockPairPortIn1(0, 4)), false);
+        assert_return(checkOnlyConnection(blockPortOut1(0, 4), JACK_PLAYBACK_PORT_1), false);
+        assert_return(checkOnlyConnection(blockPairPortOut1(0, 4), JACK_PLAYBACK_PORT_2), false);
+        // row 1 connections
+        assert_return(checkOnly2Connections(blockPortOut2(0, 1), blockPortIn1(1, 2), blockPortIn2(1, 2)), false);
+        assert_return(checkOnlyConnection(blockPortIn1(1, 2), blockPortOut2(0, 1)), false);
+        assert_return(checkOnlyConnection(blockPortIn2(1, 2), blockPortOut2(0, 1)), false);
+        assert_return(checkOnlyConnectionBothWays(blockPortOut1(1, 2), blockPortIn2(0, 4)), false);
+        assert_return(checkOnlyConnectionBothWays(blockPortOut2(1, 2), blockPairPortIn2(0, 4)), false);
         assert_return(testNoPassthrough(), false);
 
         // load empty bank
@@ -1174,6 +1202,10 @@ class HostConnectorTests : public QObject
         assert_return(checkOnlyConnectionBothWays(blockPairPortOut2(0, 2), blockPairPortIn2(0, 5)), false);
         assert_return(testNoPassthrough(), false);
 
+        // save preset state to file
+        std::string presetFileName1 = format("%s/testSideChainMoveStereoOnFirstRow1.json", PRESETFILEPATH);
+        assert_return(connector.saveCurrentPresetToFile(presetFileName1.c_str()), false);
+
         // move stereo block back inside sidechaining blocks on row 0
         // SIDEOUTBLOCK 2 becomes block 1
         assert_return(connector.reorderBlock(0, 0, 3), false);
@@ -1210,6 +1242,39 @@ class HostConnectorTests : public QObject
         assert_return(connector.replaceBlock(0, 5, nullptr), false);
         assert_return(connector.replaceBlock(0, 4, nullptr), false);
         assert_return(connector.replaceBlock(0, 1, nullptr), false);
+
+        assert_return(testPassthrough(), false);
+
+        // test loading from file
+        const std::array<std::string, NUM_PRESETS_PER_BANK> bankPresets = {
+            presetFileName1,
+            {},
+            {},
+        };
+        connector.loadBankFromPresetFiles(bankPresets, 0);
+
+        // file 1: check connections are the same as before saving the file
+        // row 0 connections
+        assert_return(checkOnlyConnection(blockPortIn1(0, 0), JACK_CAPTURE_PORT_1), false);
+        assert_return(checkOnlyConnection(blockPortIn2(0, 0), JACK_CAPTURE_PORT_2), false);
+        assert_return(checkOnlyConnectionBothWays(blockPortOut1(0, 0), blockPortIn1(0, 2)), false);
+        assert_return(checkOnlyConnectionBothWays(blockPortOut2(0, 0), blockPairPortIn1(0, 2)), false);
+        assert_return(checkOnlyConnectionBothWays(blockPortOut1(0, 2), blockPortIn1(0, 5)), false);
+        assert_return(checkOnlyConnectionBothWays(blockPairPortOut1(0, 2), blockPairPortIn1(0, 5)), false);
+        assert_return(checkOnlyConnection(blockPortOut1(0, 5), JACK_PLAYBACK_PORT_1), false);
+        assert_return(checkOnlyConnection(blockPairPortOut1(0, 5), JACK_PLAYBACK_PORT_2), false);
+        // row 1 connections
+        assert_return(checkOnlyConnectionBothWays(blockPortOut2(0, 2), blockPortIn2(0, 5)), false);
+        assert_return(checkOnlyConnectionBothWays(blockPairPortOut2(0, 2), blockPairPortIn2(0, 5)), false);
+        assert_return(testNoPassthrough(), false);
+
+        // load empty bank
+        const std::array<std::string, NUM_PRESETS_PER_BANK> bankPresetsEmpty = {
+            "1.json", // nonexisting
+            "2.json", // nonexisting
+            "3.json", // nonexisting
+        };
+        connector.loadBankFromPresetFiles(bankPresetsEmpty, 0);
 
         return true;
     }

--- a/src/tests.cpp
+++ b/src/tests.cpp
@@ -163,20 +163,20 @@ class HostConnectorTests : public QObject
         // test pass-through connections
         assert_return(testPassthrough(), false);
 
-        // // test loading single plugin
-        // assert_return(testPluginLoad(), false);
-        // // check return to pass-through connections
-        // assert_return(testPassthrough(), false);
+        // test loading single plugin
+        assert_return(testPluginLoad(), false);
+        // check return to pass-through connections
+        assert_return(testPassthrough(), false);
 
-        // // test mono chain actions
-        // assert_return(testSingleMonoChain(), false);
-        // // check return to pass-through state
-        // assert_return(testPassthrough(), false);
+        // test mono chain actions
+        assert_return(testSingleMonoChain(), false);
+        // check return to pass-through state
+        assert_return(testPassthrough(), false);
 
-        // // test stereo chain actions
-        // assert_return(testSingleStereoChain(), false);
-        // // check return to pass-through state
-        // assert_return(testPassthrough(), false);
+        // test stereo chain actions
+        assert_return(testSingleStereoChain(), false);
+        // check return to pass-through state
+        assert_return(testPassthrough(), false);
 
         // test side chain management
         assert_return(testSideChain(), false);
@@ -777,11 +777,6 @@ class HostConnectorTests : public QObject
         assert_return(testNoPassthrough(), false);
 
         // load empty bank
-        const std::array<std::string, NUM_PRESETS_PER_BANK> bankPresetsEmpty = {
-            "1.json", // nonexisting
-            "2.json", // nonexisting
-            "3.json", // nonexisting
-        };
         connector.loadBankFromPresetFiles(bankPresetsEmpty, 0);
 
         return true;
@@ -877,6 +872,52 @@ class HostConnectorTests : public QObject
         assert_return(checkNoConnections(blockPortOut2(0, 1)), false); // no sidechain
         assert_return(testNoPassthrough(), false);
 
+        // remove remaining block
+        assert_return(connector.replaceBlock(0, 1, nullptr), false);
+
+        assert_return(testPassthrough(), false);
+        
+        // switch to an empty preset and back
+        assert_return(connector.switchPreset(1), false);
+        assert_return(testPassthrough(), false);
+        assert_return(connector.switchPreset(0), false);
+
+        // check connections are the same as before saving the file
+        // row 0 connections
+        assert_return(checkOnlyConnection(blockPortIn1(0, 1), JACK_CAPTURE_PORT_1), false);
+        assert_return(checkOnly2Connections(blockPortOut1(0, 1), blockPortIn1(0, 4), blockPairPortIn1(0, 4)), false);
+        assert_return(checkOnlyConnection(blockPortIn1(0, 4), blockPortOut1(0, 1)), false);
+        assert_return(checkOnlyConnection(blockPairPortIn1(0, 4), blockPortOut1(0, 1)), false);
+        assert_return(checkOnlyConnection(blockPortOut1(0, 4), JACK_PLAYBACK_PORT_1), false);
+        assert_return(checkOnlyConnection(blockPairPortOut1(0, 4), JACK_PLAYBACK_PORT_2), false);
+        // row 1 connections
+        assert_return(checkOnly2Connections(blockPortOut2(0, 1), blockPortIn1(1, 2), blockPortIn2(1, 2)), false);
+        assert_return(checkOnlyConnection(blockPortIn1(1, 2), blockPortOut2(0, 1)), false);
+        assert_return(checkOnlyConnection(blockPortIn2(1, 2), blockPortOut2(0, 1)), false);
+        assert_return(checkOnlyConnectionBothWays(blockPortOut1(1, 2), blockPortIn2(0, 4)), false);
+        assert_return(checkOnlyConnectionBothWays(blockPortOut2(1, 2), blockPairPortIn2(0, 4)), false);
+        assert_return(testNoPassthrough(), false);
+
+        // load empty bank
+        const std::array<std::string, NUM_PRESETS_PER_BANK> bankPresetsEmpty = {
+            "1.json", // nonexisting
+            "2.json", // nonexisting
+            "3.json", // nonexisting
+        };
+        connector.loadBankFromPresetFiles(bankPresetsEmpty, 0);
+
+        assert_return(testPassthrough(), false);
+
+
+        // ***** New setup: stereo between sidechaining blocks on row 0
+
+        // branch to sidechain
+        assert_return(connector.replaceBlock(0, 1, SIDEOUTBLOCK), false);
+        assert_return(checkOnlyConnection(blockPortIn1(0, 1), JACK_CAPTURE_PORT_1), false);
+        assert_return(checkOnly2Connections(blockPortOut1(0, 1), JACK_PLAYBACK_PORT_1, JACK_PLAYBACK_PORT_2), false);
+        assert_return(checkNoConnections(blockPortOut2(0, 1)), false); // no sidechain
+        assert_return(testNoPassthrough(), false);
+
         // add stereo block on row 0
         assert_return(connector.replaceBlock(0, 2, STEREOBLOCK), false);
         assert_return(checkOnlyConnection(blockPortIn1(0, 1), JACK_CAPTURE_PORT_1), false);
@@ -926,6 +967,47 @@ class HostConnectorTests : public QObject
         // remove remaining stereo block
         assert_return(connector.replaceBlock(0, 2, nullptr), false);
         // row 0 connections
+        assert_return(checkOnlyConnection(blockPortIn1(0, 1), JACK_CAPTURE_PORT_1), false);
+        assert_return(checkOnly2Connections(blockPortOut1(0, 1), JACK_PLAYBACK_PORT_1, JACK_PLAYBACK_PORT_2), false);
+        assert_return(checkNoConnections(blockPortOut2(0, 1)), false); // no sidechain
+        assert_return(testNoPassthrough(), false);
+
+        // remove remaining block
+        assert_return(connector.replaceBlock(0, 1, nullptr), false);
+
+        assert_return(testPassthrough(), false);
+        
+        // switch to an empty preset and back
+        assert_return(connector.switchPreset(1), false);
+        assert_return(testPassthrough(), false);
+        assert_return(connector.switchPreset(0), false);
+
+        // check connections are the same as before saving the file
+        // row 0 connections
+        assert_return(checkOnlyConnection(blockPortIn1(0, 1), JACK_CAPTURE_PORT_1), false);
+        assert_return(checkOnly2Connections(blockPortOut1(0, 1), blockPortIn1(0, 2), blockPortIn2(0, 2)), false);
+        assert_return(checkOnlyConnection(blockPortIn1(0, 2), blockPortOut1(0, 1)), false);
+        assert_return(checkOnlyConnection(blockPortIn2(0, 2), blockPortOut1(0, 1)), false);
+        assert_return(checkOnlyConnectionBothWays(blockPortOut1(0, 2), blockPortIn1(0, 4)), false);
+        assert_return(checkOnlyConnectionBothWays(blockPortOut2(0, 2), blockPairPortIn1(0, 4)), false);
+        assert_return(checkOnlyConnection(blockPortOut1(0, 4), JACK_PLAYBACK_PORT_1), false);
+        assert_return(checkOnlyConnection(blockPairPortOut1(0, 4), JACK_PLAYBACK_PORT_2), false);
+        // row 1 connections
+        assert_return(checkOnly2Connections(blockPortOut2(0, 1), blockPortIn2(0, 4), blockPairPortIn2(0, 4)), false);
+        assert_return(checkOnlyConnection(blockPortIn2(0, 4), blockPortOut2(0, 1)), false);
+        assert_return(checkOnlyConnection(blockPairPortIn2(0, 4), blockPortOut2(0, 1)), false);
+        assert_return(testNoPassthrough(), false);
+
+        // load empty bank
+        connector.loadBankFromPresetFiles(bankPresetsEmpty, 0);
+
+        assert_return(testPassthrough(), false);
+
+
+        // ***** New setup: stereo between sidechaining blocks on both rows
+
+        // branch to sidechain
+        assert_return(connector.replaceBlock(0, 1, SIDEOUTBLOCK), false);
         assert_return(checkOnlyConnection(blockPortIn1(0, 1), JACK_CAPTURE_PORT_1), false);
         assert_return(checkOnly2Connections(blockPortOut1(0, 1), JACK_PLAYBACK_PORT_1, JACK_PLAYBACK_PORT_2), false);
         assert_return(checkNoConnections(blockPortOut2(0, 1)), false); // no sidechain
@@ -995,8 +1077,38 @@ class HostConnectorTests : public QObject
         assert_return(connector.replaceBlock(0, 1, nullptr), false);
 
         assert_return(testPassthrough(), false);
+        
+        // switch to an empty preset and back
+        assert_return(connector.switchPreset(1), false);
+        assert_return(testPassthrough(), false);
+        assert_return(connector.switchPreset(0), false);
 
-        // test loading from file
+        // check connections are the same as before saving the file
+        // row 0 connections
+        assert_return(checkOnlyConnection(blockPortIn1(0, 1), JACK_CAPTURE_PORT_1), false);
+        assert_return(checkOnly2Connections(blockPortOut1(0, 1), blockPortIn1(0, 2), blockPortIn2(0, 2)), false);
+        assert_return(checkOnlyConnection(blockPortIn1(0, 2), blockPortOut1(0, 1)), false);
+        assert_return(checkOnlyConnection(blockPortIn2(0, 2), blockPortOut1(0, 1)), false);
+        assert_return(checkOnlyConnectionBothWays(blockPortOut1(0, 2), blockPortIn1(0, 4)), false);
+        assert_return(checkOnlyConnectionBothWays(blockPortOut2(0, 2), blockPairPortIn1(0, 4)), false);
+        assert_return(checkOnlyConnection(blockPortOut1(0, 4), JACK_PLAYBACK_PORT_1), false);
+        assert_return(checkOnlyConnection(blockPairPortOut1(0, 4), JACK_PLAYBACK_PORT_2), false);
+        // row 1 connections
+        assert_return(checkOnly2Connections(blockPortOut2(0, 1), blockPortIn1(1, 2), blockPortIn2(1, 2)), false);
+        assert_return(checkOnlyConnection(blockPortIn1(1, 2), blockPortOut2(0, 1)), false);
+        assert_return(checkOnlyConnection(blockPortIn2(1, 2), blockPortOut2(0, 1)), false);
+        assert_return(checkOnlyConnectionBothWays(blockPortOut1(1, 2), blockPortIn2(0, 4)), false);
+        assert_return(checkOnlyConnectionBothWays(blockPortOut2(1, 2), blockPairPortIn2(0, 4)), false);
+        assert_return(testNoPassthrough(), false);
+
+        // load empty bank
+        connector.loadBankFromPresetFiles(bankPresetsEmpty, 0);
+
+        assert_return(testPassthrough(), false);
+
+
+        // ***** test loading all previously saved presets from file
+
         const std::array<std::string, NUM_PRESETS_PER_BANK> bankPresets = {
             presetFileName1,
             presetFileName2,
@@ -1060,11 +1172,6 @@ class HostConnectorTests : public QObject
         assert_return(testNoPassthrough(), false);
 
         // load empty bank
-        const std::array<std::string, NUM_PRESETS_PER_BANK> bankPresetsEmpty = {
-            "1.json", // nonexisting
-            "2.json", // nonexisting
-            "3.json", // nonexisting
-        };
         connector.loadBankFromPresetFiles(bankPresetsEmpty, 0);
 
         return true;
@@ -1296,6 +1403,37 @@ class HostConnectorTests : public QObject
 
         assert_return(testPassthrough(), false);
 
+        // switch to an empty preset and back
+        assert_return(connector.switchPreset(1), false);
+        assert_return(testPassthrough(), false);
+        assert_return(connector.switchPreset(0), false);
+
+        // check that connections returned to the saved state
+        // row 0 connections
+        assert_return(checkOnlyConnection(blockPortIn1(0, 0), JACK_CAPTURE_PORT_1), false);
+        assert_return(checkOnlyConnection(blockPortIn2(0, 0), JACK_CAPTURE_PORT_2), false);
+        assert_return(checkOnlyConnectionBothWays(blockPortOut1(0, 0), blockPortIn1(0, 2)), false);
+        assert_return(checkOnlyConnectionBothWays(blockPortOut2(0, 0), blockPairPortIn1(0, 2)), false);
+        assert_return(checkOnlyConnectionBothWays(blockPortOut1(0, 2), blockPortIn1(0, 5)), false);
+        assert_return(checkOnlyConnectionBothWays(blockPairPortOut1(0, 2), blockPairPortIn1(0, 5)), false);
+        assert_return(checkOnlyConnection(blockPortOut1(0, 5), JACK_PLAYBACK_PORT_1), false);
+        assert_return(checkOnlyConnection(blockPairPortOut1(0, 5), JACK_PLAYBACK_PORT_2), false);
+        // row 1 connections
+        assert_return(checkOnlyConnectionBothWays(blockPortOut2(0, 2), blockPortIn2(0, 5)), false);
+        assert_return(checkOnlyConnectionBothWays(blockPairPortOut2(0, 2), blockPairPortIn2(0, 5)), false);
+        assert_return(testNoPassthrough(), false);
+
+        // load empty bank
+        const std::array<std::string, NUM_PRESETS_PER_BANK> bankPresetsEmpty = {
+            "1.json", // nonexisting
+            "2.json", // nonexisting
+            "3.json", // nonexisting
+        };
+        connector.loadBankFromPresetFiles(bankPresetsEmpty, 0);
+
+        // test pass-through
+        assert_return(testPassthrough(), false);
+
         // test loading from file
         const std::array<std::string, NUM_PRESETS_PER_BANK> bankPresets = {
             presetFileName1,
@@ -1320,11 +1458,6 @@ class HostConnectorTests : public QObject
         assert_return(testNoPassthrough(), false);
 
         // load empty bank
-        const std::array<std::string, NUM_PRESETS_PER_BANK> bankPresetsEmpty = {
-            "1.json", // nonexisting
-            "2.json", // nonexisting
-            "3.json", // nonexisting
-        };
         connector.loadBankFromPresetFiles(bankPresetsEmpty, 0);
 
         return true;

--- a/src/tests.cpp
+++ b/src/tests.cpp
@@ -163,20 +163,20 @@ class HostConnectorTests : public QObject
         // test pass-through connections
         assert_return(testPassthrough(), false);
 
-        // test loading single plugin
-        assert_return(testPluginLoad(), false);
-        // check return to pass-through connections
-        assert_return(testPassthrough(), false);
+        // // test loading single plugin
+        // assert_return(testPluginLoad(), false);
+        // // check return to pass-through connections
+        // assert_return(testPassthrough(), false);
 
-        // test mono chain actions
-        assert_return(testSingleMonoChain(), false);
-        // check return to pass-through state
-        assert_return(testPassthrough(), false);
+        // // test mono chain actions
+        // assert_return(testSingleMonoChain(), false);
+        // // check return to pass-through state
+        // assert_return(testPassthrough(), false);
 
-        // test stereo chain actions
-        assert_return(testSingleStereoChain(), false);
-        // check return to pass-through state
-        assert_return(testPassthrough(), false);
+        // // test stereo chain actions
+        // assert_return(testSingleStereoChain(), false);
+        // // check return to pass-through state
+        // assert_return(testPassthrough(), false);
 
         // test side chain management
         assert_return(testSideChain(), false);
@@ -382,6 +382,30 @@ class HostConnectorTests : public QObject
         // test pass-through
         assert_return(testPassthrough(), false);
 
+        // switch to an empty preset and back
+        assert_return(connector.switchPreset(1), false);
+        assert_return(testPassthrough(), false);
+        assert_return(connector.switchPreset(0), false);
+
+        // check that connections returned to the saved state
+        assert_return(checkOnlyConnection(blockPortIn1(0, 1), JACK_CAPTURE_PORT_1), false);
+        assert_return(checkOnlyConnectionBothWays(blockPortOut1(0, 1), blockPortIn1(0, 2)), false);
+        assert_return(checkOnlyConnectionBothWays(blockPortOut1(0, 2), blockPortIn1(0, 4)), false);
+        assert_return(checkOnlyConnectionBothWays(blockPortOut1(0, 4), blockPortIn1(0, 5)), false);
+        assert_return(checkOnly2Connections(blockPortOut1(0, 5), JACK_PLAYBACK_PORT_1, JACK_PLAYBACK_PORT_2), false);
+        assert_return(testNoPassthrough(), false);
+
+        // load empty bank
+        const std::array<std::string, NUM_PRESETS_PER_BANK> bankPresetsEmpty = {
+            "1.json", // nonexisting
+            "2.json", // nonexisting
+            "3.json", // nonexisting
+        };
+        connector.loadBankFromPresetFiles(bankPresetsEmpty, 0);
+
+        // test pass-through
+        assert_return(testPassthrough(), false);
+
         // test loading from file
         const std::array<std::string, NUM_PRESETS_PER_BANK> bankPresets = {
             presetFileName,
@@ -399,11 +423,6 @@ class HostConnectorTests : public QObject
         assert_return(testNoPassthrough(), false);
 
         // load empty bank
-        const std::array<std::string, NUM_PRESETS_PER_BANK> bankPresetsEmpty = {
-            "1.json", // nonexisting
-            "2.json", // nonexisting
-            "3.json", // nonexisting
-        };
         connector.loadBankFromPresetFiles(bankPresetsEmpty, 0);
 
         return true;
@@ -697,6 +716,38 @@ class HostConnectorTests : public QObject
 
         // remove remaining block
         assert_return(connector.replaceBlock(0, 2, nullptr), false);
+
+        assert_return(testPassthrough(), false);
+
+        // switch to an empty preset and back
+        assert_return(connector.switchPreset(1), false);
+        assert_return(testPassthrough(), false);
+        assert_return(connector.switchPreset(0), false);
+
+        // check connections are the same as before saving the file
+        assert_return(checkOnlyConnection(blockPortIn1(0, 0), JACK_CAPTURE_PORT_1), false);
+        assert_return(checkOnly2Connections(blockPortOut1(0, 0), blockPortIn1(0, 1), blockPortIn2(0, 1)), false);
+        assert_return(checkOnlyConnection(blockPortIn1(0, 1), blockPortOut1(0, 0)), false);
+        assert_return(checkOnlyConnection(blockPortIn2(0, 1), blockPortOut1(0, 0)), false);
+        assert_return(checkOnlyConnectionBothWays(blockPortOut1(0, 1), blockPortIn1(0, 2)), false);
+        assert_return(checkOnlyConnectionBothWays(blockPortOut2(0, 1), blockPortIn2(0, 2)), false);
+        assert_return(checkOnlyConnectionBothWays(blockPortOut1(0, 2), blockPortIn1(0, 3)), false);
+        assert_return(checkOnlyConnectionBothWays(blockPortOut2(0, 2), blockPairPortIn1(0, 3)), false);
+        assert_return(checkOnlyConnectionBothWays(blockPortOut1(0, 3), blockPortIn1(0, 4)), false);
+        assert_return(checkOnlyConnectionBothWays(blockPairPortOut1(0, 3), blockPairPortIn1(0, 4)), false);
+        assert_return(checkOnlyConnectionBothWays(blockPortOut1(0, 4), blockPortIn1(0, 5)), false);
+        assert_return(checkOnlyConnectionBothWays(blockPairPortOut1(0, 4), blockPortIn2(0, 5)), false);
+        assert_return(checkOnlyConnection(blockPortOut1(0, 5), JACK_PLAYBACK_PORT_1), false);
+        assert_return(checkOnlyConnection(blockPortOut2(0, 5), JACK_PLAYBACK_PORT_2), false);
+        assert_return(testNoPassthrough(), false);
+
+        // load empty bank
+        const std::array<std::string, NUM_PRESETS_PER_BANK> bankPresetsEmpty = {
+            "1.json", // nonexisting
+            "2.json", // nonexisting
+            "3.json", // nonexisting
+        };
+        connector.loadBankFromPresetFiles(bankPresetsEmpty, 0);
 
         assert_return(testPassthrough(), false);
 


### PR DESCRIPTION
- Add test cases for switchPreset (also to test how it returns previous preset to saved state) and hostLoadPreset (via loadBankFromPresetFiles)
- Use hostEnsureStereoChain more widely for creating needed pairs for blocks and making connections
- Fixes bugs / failing tests in loading from file presets that contain stereo and sidechain
- Fixes bugs / failing tests in switchPreset's restoring of saved state of previous preset
- Remove unnecessary code
- Move repeated code to helper functions