### PR TITLE
Add multi_pre_run host command

### DIFF
--- a/src/host.cpp
+++ b/src/host.cpp
@@ -1445,7 +1445,7 @@ bool Host::multi_pre_run(const uint8_t reset_value,
                          const unsigned int instance_count,
                          const int16_t* const instances)
 {
-    VALIDATE_INSTANCE_COUNT(instance_count);
+    VALIDATE(instance_count >= 1 && instance_count < kMaxHostInstances)
 
     std::string msg = format("multi_pre_run %u %u", reset_value, instance_count);
 

--- a/src/host.cpp
+++ b/src/host.cpp
@@ -964,6 +964,24 @@ bool Host::params_flush(const int16_t instance_number,
     return impl->writeMessageAndWait(msg);
 }
 
+bool Host::pre_run(const int16_t instance_number,
+                   const uint8_t reset_value,
+                   const unsigned int param_count,
+                   const flushed_param* const params)
+{
+    VALIDATE_INSTANCE_NUMBER(instance_number)
+
+    std::string msg = format("pre_run %d %u %u", instance_number, reset_value, param_count);
+
+    for (unsigned int i = 0; i < param_count; ++i)
+    {
+        VALIDATE_SYMBOL(params[i].symbol)
+        msg += format(" %s %f", params[i].symbol, params[i].value);
+    }
+
+    return impl->writeMessageAndWait(msg);
+}
+
 bool Host::patch_set(const int16_t instance_number, const char* const property_uri, const char* const value)
 {
     VALIDATE_INSTANCE_NUMBER(instance_number)
@@ -1445,7 +1463,7 @@ bool Host::multi_pre_run(const uint8_t reset_value,
                          const unsigned int instance_count,
                          const int16_t* const instances)
 {
-    VALIDATE(instance_count >= 1 && instance_count < kMaxHostInstances)
+    VALIDATE_INSTANCE_COUNT(instance_count);
 
     std::string msg = format("multi_pre_run %u %u", reset_value, instance_count);
 

--- a/src/host.cpp
+++ b/src/host.cpp
@@ -1439,6 +1439,33 @@ bool Host::multi_params_flush(const uint8_t reset_value,
     return impl->writeMessageAndWait(msg);
 }
 
+bool Host::multi_pre_run(const uint8_t reset_value,
+                         const unsigned int param_count,
+                         const flushed_param* const params,
+                         const unsigned int instance_count,
+                         const int16_t* const instances)
+{
+    VALIDATE_INSTANCE_COUNT(instance_count);
+
+    std::string msg = format("multi_pre_run %u %u", reset_value, instance_count);
+
+    for (unsigned int i = 0; i < instance_count; ++i)
+    {
+        VALIDATE_INSTANCE_NUMBER(instances[i])
+        msg += format(" %d", instances[i]);
+    }
+
+    msg += format(" %u", param_count);
+
+    for (unsigned int i = 0; i < param_count; ++i)
+    {
+        VALIDATE_SYMBOL(params[i].symbol)
+        msg += format(" %s %f", params[i].symbol, params[i].value);
+    }
+
+    return impl->writeMessageAndWait(msg);
+}
+
 bool Host::poll_feedback(FeedbackCallback* const callback) const
 {
     return impl->poll(callback);

--- a/src/host.hpp
+++ b/src/host.hpp
@@ -483,12 +483,23 @@ struct Host {
 
    /**
      * flush several param values at once and trigger reset if available (multiple instance variant)
+     * all instances must be in activated state
      */
     bool multi_params_flush(uint8_t reset_value,
                             unsigned int param_count,
                             const flushed_param* params,
                             unsigned int instance_count,
                             const int16_t* instances);
+
+   /**
+     * pre-run and flush several param values at once and trigger reset if available (for multiple instance)
+     * all instances must be in deactivated state
+     */
+    bool multi_pre_run(uint8_t reset_value,
+                       unsigned int param_count,
+                       const flushed_param* params,
+                       unsigned int instance_count,
+                       const int16_t* instances);
 
    /**
      * poll feedback port for messages, triggering a callback for each one

--- a/src/host.hpp
+++ b/src/host.hpp
@@ -239,6 +239,15 @@ struct Host {
                       const flushed_param* params);
 
     /**
+     * pre-run and flush several param values at once and trigger reset if available
+     * instance must be in deactivated state
+     */
+    bool pre_run(int16_t instance_number,
+                 uint8_t reset_value,
+                 unsigned int param_count,
+                 const flushed_param* params);
+
+    /**
      * set the value of a patch property
      */
     bool patch_set(int16_t instance_number, const char* property_uri, const char* value);
@@ -492,7 +501,7 @@ struct Host {
                             const int16_t* instances);
 
    /**
-     * pre-run and flush several param values at once and trigger reset if available (for multiple instance)
+     * pre-run and flush several param values at once and trigger reset if available (multiple instance variant)
      * all instances must be in deactivated state
      */
     bool multi_pre_run(uint8_t reset_value,

--- a/src/host.hpp
+++ b/src/host.hpp
@@ -240,7 +240,7 @@ struct Host {
 
     /**
      * pre-run and flush several param values at once and trigger reset if available
-     * instance must be in deactivated state
+     * instance must be in deactivated state or global processing disabled (and plugin does not have isLive flag)
      */
     bool pre_run(int16_t instance_number,
                  uint8_t reset_value,
@@ -502,7 +502,7 @@ struct Host {
 
    /**
      * pre-run and flush several param values at once and trigger reset if available (multiple instance variant)
-     * all instances must be in deactivated state
+     * all instances must be in deactivated state or global processing disabled (and plugins do not have isLive flag)
      */
     bool multi_pre_run(uint8_t reset_value,
                        unsigned int param_count,


### PR DESCRIPTION
Hopefully this does it...

While handling the host side I noticed `multi_params_flush` is racy if called for deactivated plugins so that's why there is a comment about it now.

We should use `multi_params_flush` for activated plugins / current preset and `multi_pre_run` for deactivated plugins / preloaded plugins.
