### PR TITLE
replaceBlockWhileKeepingCurrentData refactor

### DIFF
--- a/src/connector.cpp
+++ b/src/connector.cpp
@@ -1762,8 +1762,12 @@ bool HostConnector::replaceBlock(const uint8_t row,
 
             if (keepCurrentData)
             {
-                // the only parts of blockdata that should be updated from new plugin's info
                 // name, abbreviation and category assumed to be same between old and new plugin
+                assert(blockdata.meta.name == plugin->name);
+                assert(blockdata.meta.abbreviation == plugin->abbreviation);
+                assert(blockdata.meta.category == plugin->category);
+                
+                // the only parts of blockdata that should be updated from new plugin's info
                 blockdata.uri = plugin->uri;
                 blockdata.plugin = plugin;
                 blockdata.meta.flags = plugin->flags;

--- a/src/connector.cpp
+++ b/src/connector.cpp
@@ -1759,23 +1759,11 @@ bool HostConnector::replaceBlock(const uint8_t row,
         if (added)
         {
             ++_current.numLoadedPlugins;
-            initBlock(blockdata, plugin, numInputs, numOutputs, numSideInputs, numSideOutputs);
+            initBlock(blockdata, plugin, numInputs, numOutputs, numSideInputs, numSideOutputs, blockDataToCopy);
 
             // copy data from old block
             if (blockDataToCopy != nullptr)
             {
-                const Block& blockcopy(*blockDataToCopy);
-                blockdata.enabled = blockcopy.enabled;
-                blockdata.quickPotSymbol = blockcopy.quickPotSymbol;
-                blockdata.meta.enable = blockcopy.meta.enable;
-                blockdata.meta.quickPotIndex = blockcopy.meta.quickPotIndex;
-                blockdata.meta.numParametersInScenes = blockcopy.meta.numParametersInScenes;
-                blockdata.meta.numPropertiesInScenes = blockcopy.meta.numPropertiesInScenes;
-                blockdata.parameters = blockcopy.parameters;
-                blockdata.properties = blockcopy.properties;
-                blockdata.sceneValues = blockcopy.sceneValues;
-                blockdata.lastSavedSceneValues = blockcopy.lastSavedSceneValues;
-
                 if (!blockdata.enabled)
                 {
                     hostBypassBlockPair(hbp, true);
@@ -7025,23 +7013,14 @@ void HostConnector::initBlock(HostConnector::Block& blockdata,
                               const uint8_t numInputs,
                               const uint8_t numOutputs,
                               const uint8_t numSideInputs,
-                              const uint8_t numSideOutputs) const
+                              const uint8_t numSideOutputs, 
+                              const Block* const blockDataToCopy) const
 {
     assert(plugin != nullptr);
 
-    blockdata.enabled = true;
     blockdata.uri = plugin->uri;
-    blockdata.quickPotSymbol.clear();
     blockdata.plugin = plugin;
-
-    blockdata.meta.enable.hasScenes = false;
-    blockdata.meta.enable.hwbinding = UINT8_MAX;
-    blockdata.meta.enable.tempSceneState = kTemporarySceneNone;
-    blockdata.meta.enable.changesNotSavedToPreset = false;
     blockdata.meta.flags = plugin->flags;
-    blockdata.meta.quickPotIndex = 0;
-    blockdata.meta.numParametersInScenes = 0;
-    blockdata.meta.numPropertiesInScenes = 0;
     blockdata.meta.numInputs = numInputs;
     blockdata.meta.numOutputs = numOutputs;
     blockdata.meta.numSideInputs = numSideInputs;
@@ -7049,6 +7028,41 @@ void HostConnector::initBlock(HostConnector::Block& blockdata,
     blockdata.meta.name = plugin->name;
     blockdata.meta.abbreviation = plugin->abbreviation;
     blockdata.meta.category = plugin->category;
+
+    if (blockDataToCopy != nullptr)
+    {
+        const Block& blockcopy(*blockDataToCopy);
+        
+        blockdata.enabled = blockcopy.enabled;
+        blockdata.quickPotSymbol = blockcopy.quickPotSymbol;
+
+        blockdata.meta.enable = blockcopy.meta.enable;
+        blockdata.meta.quickPotIndex = blockcopy.meta.quickPotIndex;
+        blockdata.meta.numParametersInScenes = blockcopy.meta.numParametersInScenes;
+        blockdata.meta.numPropertiesInScenes = blockcopy.meta.numPropertiesInScenes;
+
+        blockdata.parameters = blockcopy.parameters;
+        blockdata.properties = blockcopy.properties;
+        blockdata.sceneValues = blockcopy.sceneValues;
+        blockdata.lastSavedSceneValues = blockcopy.lastSavedSceneValues;
+
+        // no need to do init of parameters, properties, scenes below
+        // as they were all just copied
+        return;
+    }
+    else
+    {
+        blockdata.enabled = true;
+        blockdata.quickPotSymbol.clear();
+
+        blockdata.meta.enable.hasScenes = false;
+        blockdata.meta.enable.hwbinding = UINT8_MAX;
+        blockdata.meta.enable.tempSceneState = kTemporarySceneNone;
+        blockdata.meta.enable.changesNotSavedToPreset = false;
+        blockdata.meta.quickPotIndex = 0;
+        blockdata.meta.numParametersInScenes = 0;
+        blockdata.meta.numPropertiesInScenes = 0;
+    }
 
     blockdata.parameterSymbolToIndexMap.clear();
     blockdata.propertyURIToIndexMap.clear();

--- a/src/connector.cpp
+++ b/src/connector.cpp
@@ -1763,6 +1763,7 @@ bool HostConnector::replaceBlock(const uint8_t row,
             if (keepCurrentData)
             {
                 // the only parts of blockdata that should be updated from new plugin's info
+                // name, abbreviation and category assumed to be same between old and new plugin
                 blockdata.uri = plugin->uri;
                 blockdata.plugin = plugin;
                 blockdata.meta.flags = plugin->flags;
@@ -1770,9 +1771,6 @@ bool HostConnector::replaceBlock(const uint8_t row,
                 blockdata.meta.numOutputs = numOutputs;
                 blockdata.meta.numSideInputs = numSideInputs;
                 blockdata.meta.numSideOutputs = numSideOutputs;
-                blockdata.meta.name = plugin->name;
-                blockdata.meta.abbreviation = plugin->abbreviation;
-                blockdata.meta.category = plugin->category;
 
                 if (!blockdata.enabled)
                 {
@@ -1812,7 +1810,7 @@ bool HostConnector::replaceBlock(const uint8_t row,
                 
                 // initialize states, because there will be no updates on initial Lv2ParameterStateNone state
                 if (keepCurrentData)
-                    _current.chains[row].blocks[block].parameters[p].meta.state = Lv2ParameterStateNone;
+                    blockdata.parameters[p].meta.state = Lv2ParameterStateNone;
             }
 
             hostPrerunBlockPair(hbp, LV2_KXSTUDIO_PROPERTIES_RESET_FULL, params);

--- a/src/connector.cpp
+++ b/src/connector.cpp
@@ -1563,7 +1563,11 @@ bool HostConnector::reorderBlock(const uint8_t row, const uint8_t orig, const ui
 
 // --------------------------------------------------------------------------------------------------------------------
 
-bool HostConnector::replaceBlock(const uint8_t row, const uint8_t block, const char* const uri, bool clearBindingsForReplacementBlock, const Block * const blockDataToCopy)
+bool HostConnector::replaceBlock(const uint8_t row, 
+                                 const uint8_t block, 
+                                 const char* const uri, 
+                                 bool clearBindingsForReplacementBlock, 
+                                 const Block * const blockDataToCopy)
 {
     mod_log_debug("replaceBlock(%u, %u, \"%s\")", row, block, uri);
     assert(row < NUM_BLOCK_CHAIN_ROWS);
@@ -1808,7 +1812,7 @@ bool HostConnector::replaceBlock(const uint8_t row, const uint8_t block, const c
                 if (blockDataToCopy != nullptr)
                     _current.chains[row].blocks[block].parameters[p].meta.state = Lv2ParameterStateNone;
             }
-            
+
             hostPrerunBlockPair(hbp, LV2_KXSTUDIO_PROPERTIES_RESET_FULL, params);
 
             // activate block pair

--- a/src/connector.cpp
+++ b/src/connector.cpp
@@ -1759,11 +1759,23 @@ bool HostConnector::replaceBlock(const uint8_t row,
         if (added)
         {
             ++_current.numLoadedPlugins;
-            initBlock(blockdata, plugin, numInputs, numOutputs, numSideInputs, numSideOutputs, blockDataToCopy);
+            initBlock(blockdata, plugin, numInputs, numOutputs, numSideInputs, numSideOutputs);
 
             // copy data from old block
             if (blockDataToCopy != nullptr)
             {
+                const Block& blockcopy(*blockDataToCopy);
+                blockdata.enabled = blockcopy.enabled;
+                blockdata.quickPotSymbol = blockcopy.quickPotSymbol;
+                blockdata.meta.enable = blockcopy.meta.enable;
+                blockdata.meta.quickPotIndex = blockcopy.meta.quickPotIndex;
+                blockdata.meta.numParametersInScenes = blockcopy.meta.numParametersInScenes;
+                blockdata.meta.numPropertiesInScenes = blockcopy.meta.numPropertiesInScenes;
+                blockdata.parameters = blockcopy.parameters;
+                blockdata.properties = blockcopy.properties;
+                blockdata.sceneValues = blockcopy.sceneValues;
+                blockdata.lastSavedSceneValues = blockcopy.lastSavedSceneValues;
+
                 if (!blockdata.enabled)
                 {
                     hostBypassBlockPair(hbp, true);
@@ -7013,14 +7025,23 @@ void HostConnector::initBlock(HostConnector::Block& blockdata,
                               const uint8_t numInputs,
                               const uint8_t numOutputs,
                               const uint8_t numSideInputs,
-                              const uint8_t numSideOutputs, 
-                              const Block* const blockDataToCopy) const
+                              const uint8_t numSideOutputs) const
 {
     assert(plugin != nullptr);
 
+    blockdata.enabled = true;
     blockdata.uri = plugin->uri;
+    blockdata.quickPotSymbol.clear();
     blockdata.plugin = plugin;
+
+    blockdata.meta.enable.hasScenes = false;
+    blockdata.meta.enable.hwbinding = UINT8_MAX;
+    blockdata.meta.enable.tempSceneState = kTemporarySceneNone;
+    blockdata.meta.enable.changesNotSavedToPreset = false;
     blockdata.meta.flags = plugin->flags;
+    blockdata.meta.quickPotIndex = 0;
+    blockdata.meta.numParametersInScenes = 0;
+    blockdata.meta.numPropertiesInScenes = 0;
     blockdata.meta.numInputs = numInputs;
     blockdata.meta.numOutputs = numOutputs;
     blockdata.meta.numSideInputs = numSideInputs;
@@ -7028,41 +7049,6 @@ void HostConnector::initBlock(HostConnector::Block& blockdata,
     blockdata.meta.name = plugin->name;
     blockdata.meta.abbreviation = plugin->abbreviation;
     blockdata.meta.category = plugin->category;
-
-    if (blockDataToCopy != nullptr)
-    {
-        const Block& blockcopy(*blockDataToCopy);
-        
-        blockdata.enabled = blockcopy.enabled;
-        blockdata.quickPotSymbol = blockcopy.quickPotSymbol;
-
-        blockdata.meta.enable = blockcopy.meta.enable;
-        blockdata.meta.quickPotIndex = blockcopy.meta.quickPotIndex;
-        blockdata.meta.numParametersInScenes = blockcopy.meta.numParametersInScenes;
-        blockdata.meta.numPropertiesInScenes = blockcopy.meta.numPropertiesInScenes;
-
-        blockdata.parameters = blockcopy.parameters;
-        blockdata.properties = blockcopy.properties;
-        blockdata.sceneValues = blockcopy.sceneValues;
-        blockdata.lastSavedSceneValues = blockcopy.lastSavedSceneValues;
-
-        // no need to do init of parameters, properties, scenes below
-        // as they were all just copied
-        return;
-    }
-    else
-    {
-        blockdata.enabled = true;
-        blockdata.quickPotSymbol.clear();
-
-        blockdata.meta.enable.hasScenes = false;
-        blockdata.meta.enable.hwbinding = UINT8_MAX;
-        blockdata.meta.enable.tempSceneState = kTemporarySceneNone;
-        blockdata.meta.enable.changesNotSavedToPreset = false;
-        blockdata.meta.quickPotIndex = 0;
-        blockdata.meta.numParametersInScenes = 0;
-        blockdata.meta.numPropertiesInScenes = 0;
-    }
 
     blockdata.parameterSymbolToIndexMap.clear();
     blockdata.propertyURIToIndexMap.clear();

--- a/src/connector.cpp
+++ b/src/connector.cpp
@@ -1563,7 +1563,7 @@ bool HostConnector::reorderBlock(const uint8_t row, const uint8_t orig, const ui
 
 // --------------------------------------------------------------------------------------------------------------------
 
-bool HostConnector::replaceBlock(const uint8_t row, const uint8_t block, const char* const uri, bool clearBindingsForReplacementBlock)
+bool HostConnector::replaceBlock(const uint8_t row, const uint8_t block, const char* const uri, bool clearBindingsForReplacementBlock, const Block * const blockDataToCopy)
 {
     mod_log_debug("replaceBlock(%u, %u, \"%s\")", row, block, uri);
     assert(row < NUM_BLOCK_CHAIN_ROWS);
@@ -1757,6 +1757,41 @@ bool HostConnector::replaceBlock(const uint8_t row, const uint8_t block, const c
             ++_current.numLoadedPlugins;
             initBlock(blockdata, plugin, numInputs, numOutputs, numSideInputs, numSideOutputs);
 
+            // copy data from old block
+            if (blockDataToCopy != nullptr)
+            {
+                const Block& blockcopy(*blockDataToCopy);
+                blockdata.enabled = blockcopy.enabled;
+                blockdata.quickPotSymbol = blockcopy.quickPotSymbol;
+                blockdata.meta.enable = blockcopy.meta.enable;
+                blockdata.meta.quickPotIndex = blockcopy.meta.quickPotIndex;
+                blockdata.meta.numParametersInScenes = blockcopy.meta.numParametersInScenes;
+                blockdata.meta.numPropertiesInScenes = blockcopy.meta.numPropertiesInScenes;
+                blockdata.parameters = blockcopy.parameters;
+                blockdata.properties = blockcopy.properties;
+                blockdata.sceneValues = blockcopy.sceneValues;
+                blockdata.lastSavedSceneValues = blockcopy.lastSavedSceneValues;
+
+                if (!blockdata.enabled)
+                {
+                    hostBypassBlockPair(hbp, true);
+                }
+
+                // TODO: check if also needed for regular replace case
+                // previously used only in replaceBlockWhileKeepingData
+                for (uint8_t p = 0; p < MAX_PARAMS_PER_BLOCK; ++p)
+                {
+                    const Property& propdata(blockdata.properties[p]);
+                    if (isNullURI(propdata.uri))
+                        break;
+                    if ((propdata.meta.flags & Lv2PropertyNotAllowedToChange) != 0)
+                        continue;
+
+                    if (propdata.value != propdata.meta.defpath)
+                        hostPatchSetBlockPair(hbp, propdata);
+                }
+            }
+
             for (uint8_t p = 0; p < MAX_PARAMS_PER_BLOCK; ++p)
             {
                 Parameter& paramdata(blockdata.parameters[p]);
@@ -1768,8 +1803,12 @@ bool HostConnector::replaceBlock(const uint8_t row, const uint8_t block, const c
                 // if defttl (default from ttl) does not match running value, make sure to inform the plugin
                 if (isNotEqual(paramdata.value, paramdata.meta.defttl))
                     params.push_back({ paramdata.symbol.c_str(), paramdata.value });
+                
+                // initialize states, because there will be no updates on initial Lv2ParameterStateNone state
+                if (blockDataToCopy != nullptr)
+                    _current.chains[row].blocks[block].parameters[p].meta.state = Lv2ParameterStateNone;
             }
-
+            
             hostPrerunBlockPair(hbp, LV2_KXSTUDIO_PROPERTIES_RESET_FULL, params);
 
             // activate block pair
@@ -1956,67 +1995,8 @@ bool HostConnector::replaceBlockWhileKeepingCurrentData(const uint8_t row, const
         return false;
     }
 
-    if (! replaceBlock(row, block, uri, false))
+    if (! replaceBlock(row, block, uri, false, &blockcopy))
         return false;
-
-    {
-        Block& blockdata = _current.chains[row].blocks[block];
-        blockdata.enabled = blockcopy.enabled;
-        blockdata.quickPotSymbol = blockcopy.quickPotSymbol;
-        blockdata.meta.enable = blockcopy.meta.enable;
-        blockdata.meta.quickPotIndex = blockcopy.meta.quickPotIndex;
-        blockdata.meta.numParametersInScenes = blockcopy.meta.numParametersInScenes;
-        blockdata.meta.numPropertiesInScenes = blockcopy.meta.numPropertiesInScenes;
-        blockdata.parameters = blockcopy.parameters;
-        blockdata.properties = blockcopy.properties;
-        blockdata.sceneValues = blockcopy.sceneValues;
-        blockdata.lastSavedSceneValues = blockcopy.lastSavedSceneValues;
-    }
-
-    const HostBlockPair hbp = _mapper.get(_current.preset, row, block);
-    assert_return(hbp.id != kMaxHostInstances, false);
-
-    std::vector<flushed_param> params;
-    params.reserve(MAX_PARAMS_PER_BLOCK);
-
-    for (uint8_t p = 0; p < MAX_PARAMS_PER_BLOCK; ++p)
-    {
-        const Parameter& paramdata(blockcopy.parameters[p]);
-        if (isNullURI(paramdata.symbol))
-            break;
-        if ((paramdata.meta.flags & Lv2ParameterNotAllowedToChange) != 0)
-            continue;
-
-        if (isNotEqual(paramdata.value, paramdata.meta.def))
-            params.push_back({ paramdata.symbol.c_str(), paramdata.value });
-
-        // initialize states, because there will be no updates on initial Lv2ParameterStateNone state
-        _current.chains[row].blocks[block].parameters[p].meta.state = Lv2ParameterStateNone;
-    }
-
-    {
-        const Host::NonBlockingScopeWithAudioFades hnbs(_host);
-
-        if (!blockcopy.enabled)
-        {
-            hostBypassBlockPair(hbp, true);
-        }
-
-        // TODO: should be replaced with prerun, but that needs to be done in replaceBlock before activation and connections
-        hostParamsFlushBlockPair(hbp, LV2_KXSTUDIO_PROPERTIES_RESET_FULL, params);
-        
-        for (uint8_t p = 0; p < MAX_PARAMS_PER_BLOCK; ++p)
-        {
-            const Property& propdata(blockcopy.properties[p]);
-            if (isNullURI(propdata.uri))
-                break;
-            if ((propdata.meta.flags & Lv2PropertyNotAllowedToChange) != 0)
-                continue;
-
-            if (propdata.value != propdata.meta.defpath)
-                hostPatchSetBlockPair(hbp, propdata);
-        }
-    }
 
     _current.dirty = true;
     return true;

--- a/src/connector.cpp
+++ b/src/connector.cpp
@@ -1567,7 +1567,7 @@ bool HostConnector::replaceBlock(const uint8_t row,
                                  const uint8_t block, 
                                  const char* const uri, 
                                  const bool clearBindingsForReplacementBlock, 
-                                 const Block* const blockDataToCopy)
+                                 const bool keepCurrentData)
 {
     mod_log_debug("replaceBlock(%u, %u, \"%s\")", row, block, uri);
     assert(row < NUM_BLOCK_CHAIN_ROWS);
@@ -1759,22 +1759,20 @@ bool HostConnector::replaceBlock(const uint8_t row,
         if (added)
         {
             ++_current.numLoadedPlugins;
-            initBlock(blockdata, plugin, numInputs, numOutputs, numSideInputs, numSideOutputs);
 
-            // copy data from old block
-            if (blockDataToCopy != nullptr)
+            if (keepCurrentData)
             {
-                const Block& blockcopy(*blockDataToCopy);
-                blockdata.enabled = blockcopy.enabled;
-                blockdata.quickPotSymbol = blockcopy.quickPotSymbol;
-                blockdata.meta.enable = blockcopy.meta.enable;
-                blockdata.meta.quickPotIndex = blockcopy.meta.quickPotIndex;
-                blockdata.meta.numParametersInScenes = blockcopy.meta.numParametersInScenes;
-                blockdata.meta.numPropertiesInScenes = blockcopy.meta.numPropertiesInScenes;
-                blockdata.parameters = blockcopy.parameters;
-                blockdata.properties = blockcopy.properties;
-                blockdata.sceneValues = blockcopy.sceneValues;
-                blockdata.lastSavedSceneValues = blockcopy.lastSavedSceneValues;
+                // the only parts of blockdata that should be updated from new plugin's info
+                blockdata.uri = plugin->uri;
+                blockdata.plugin = plugin;
+                blockdata.meta.flags = plugin->flags;
+                blockdata.meta.numInputs = numInputs;
+                blockdata.meta.numOutputs = numOutputs;
+                blockdata.meta.numSideInputs = numSideInputs;
+                blockdata.meta.numSideOutputs = numSideOutputs;
+                blockdata.meta.name = plugin->name;
+                blockdata.meta.abbreviation = plugin->abbreviation;
+                blockdata.meta.category = plugin->category;
 
                 if (!blockdata.enabled)
                 {
@@ -1795,6 +1793,10 @@ bool HostConnector::replaceBlock(const uint8_t row,
                         hostPatchSetBlockPair(hbp, propdata);
                 }
             }
+            else
+            {
+                initBlock(blockdata, plugin, numInputs, numOutputs, numSideInputs, numSideOutputs);
+            }
 
             for (uint8_t p = 0; p < MAX_PARAMS_PER_BLOCK; ++p)
             {
@@ -1809,7 +1811,7 @@ bool HostConnector::replaceBlock(const uint8_t row,
                     params.push_back({ paramdata.symbol.c_str(), paramdata.value });
                 
                 // initialize states, because there will be no updates on initial Lv2ParameterStateNone state
-                if (blockDataToCopy != nullptr)
+                if (keepCurrentData)
                     _current.chains[row].blocks[block].parameters[p].meta.state = Lv2ParameterStateNone;
             }
 
@@ -1999,7 +2001,7 @@ bool HostConnector::replaceBlockWhileKeepingCurrentData(const uint8_t row, const
         return false;
     }
 
-    if (! replaceBlock(row, block, uri, false, &blockcopy))
+    if (! replaceBlock(row, block, uri, false, true))
         return false;
 
     _current.dirty = true;

--- a/src/connector.cpp
+++ b/src/connector.cpp
@@ -1566,8 +1566,8 @@ bool HostConnector::reorderBlock(const uint8_t row, const uint8_t orig, const ui
 bool HostConnector::replaceBlock(const uint8_t row, 
                                  const uint8_t block, 
                                  const char* const uri, 
-                                 bool clearBindingsForReplacementBlock, 
-                                 const Block * const blockDataToCopy)
+                                 const bool clearBindingsForReplacementBlock, 
+                                 const Block* const blockDataToCopy)
 {
     mod_log_debug("replaceBlock(%u, %u, \"%s\")", row, block, uri);
     assert(row < NUM_BLOCK_CHAIN_ROWS);

--- a/src/connector.hpp
+++ b/src/connector.hpp
@@ -520,7 +520,8 @@ public:
                       bool keepCurrentData = false);
 
     // replace a block with another lv2 plugin that matches current one (referenced by its URI)
-    // the current and new plugin must have the exact same parameters and properties
+    // the current and new plugin must have the exact same parameters, properties, name, 
+    // abbreviation and category
     // returning false means the block was unchanged
     bool replaceBlockWhileKeepingCurrentData(uint8_t row, uint8_t block, const char* uri);
 

--- a/src/connector.hpp
+++ b/src/connector.hpp
@@ -511,12 +511,13 @@ public:
     // passing null, empty string or URI of the current block as the URI means clearing the block
     // returning false means the block was unchanged
     // use clearBindingsForReplacementBlock=false only when making sure the new plugin has same control inputs
-    // blockDataToCopy is ignored if replacing block with itself, block is still cleared
+    // keepCurrentData can only be used if new and old block have the exact same parameters and properties
+    // keepCurrentData is ignored if replacing block with itself, block is still cleared
     bool replaceBlock(uint8_t row, 
                       uint8_t block, 
                       const char* uri, 
                       bool clearBindingsForReplacementBlock = true, 
-                      const Block* blockDataToCopy = nullptr);
+                      bool keepCurrentData = false);
 
     // replace a block with another lv2 plugin that matches current one (referenced by its URI)
     // the current and new plugin must have the exact same parameters and properties

--- a/src/connector.hpp
+++ b/src/connector.hpp
@@ -910,12 +910,15 @@ private:
     void hostFeedbackCallback(const HostFeedbackData& data) override;
 
     // init block using plugin default values, optionally fill index maps
+    // optionally copy data from another block 
+    // blockDataToCopy and new plugin must have the exact same parameters and properties
     void initBlock(Block& blockdata,
                    const std::shared_ptr<const Lv2Plugin>& plugin,
                    uint8_t numInputs,
                    uint8_t numOutputs,
                    uint8_t numSideInputs,
-                   uint8_t numSideOutputs) const;
+                   uint8_t numSideOutputs, 
+                   const Block* blockDataToCopy = nullptr) const;
 
     void allocBlock(Block& blockdata) const;
     void resetBlock(Block& blockdata) const;

--- a/src/connector.hpp
+++ b/src/connector.hpp
@@ -512,7 +512,11 @@ public:
     // returning false means the block was unchanged
     // use clearBindingsForReplacementBlock=false only when making sure the new plugin has same control inputs
     // blockDataToCopy is ignored if replacing block with itself, block is still cleared
-    bool replaceBlock(uint8_t row, uint8_t block, const char* uri, bool clearBindingsForReplacementBlock = true, const Block * const blockDataToCopy = nullptr);
+    bool replaceBlock(uint8_t row, 
+                      uint8_t block, 
+                      const char* uri, 
+                      bool clearBindingsForReplacementBlock = true, 
+                      const Block* blockDataToCopy = nullptr);
 
     // replace a block with another lv2 plugin that matches current one (referenced by its URI)
     // the current and new plugin must have the exact same parameters and properties

--- a/src/connector.hpp
+++ b/src/connector.hpp
@@ -910,15 +910,12 @@ private:
     void hostFeedbackCallback(const HostFeedbackData& data) override;
 
     // init block using plugin default values, optionally fill index maps
-    // optionally copy data from another block 
-    // blockDataToCopy and new plugin must have the exact same parameters and properties
     void initBlock(Block& blockdata,
                    const std::shared_ptr<const Lv2Plugin>& plugin,
                    uint8_t numInputs,
                    uint8_t numOutputs,
                    uint8_t numSideInputs,
-                   uint8_t numSideOutputs, 
-                   const Block* blockDataToCopy = nullptr) const;
+                   uint8_t numSideOutputs) const;
 
     void allocBlock(Block& blockdata) const;
     void resetBlock(Block& blockdata) const;

--- a/src/connector.hpp
+++ b/src/connector.hpp
@@ -508,10 +508,11 @@ public:
     bool reorderBlock(uint8_t row, uint8_t orig, uint8_t dest);
 
     // replace a block with another lv2 plugin (referenced by its URI)
-    // passing null or empty string as the URI means clearing the block
+    // passing null, empty string or URI of the current block as the URI means clearing the block
     // returning false means the block was unchanged
     // use clearBindingsForReplacementBlock=false only when making sure the new plugin has same control inputs
-    bool replaceBlock(uint8_t row, uint8_t block, const char* uri, bool clearBindingsForReplacementBlock = true);
+    // blockDataToCopy is ignored if replacing block with itself, block is still cleared
+    bool replaceBlock(uint8_t row, uint8_t block, const char* uri, bool clearBindingsForReplacementBlock = true, const Block * const blockDataToCopy = nullptr);
 
     // replace a block with another lv2 plugin that matches current one (referenced by its URI)
     // the current and new plugin must have the exact same parameters and properties


### PR DESCRIPTION
Next little step in the pre-run saga: integrate replaceBlockWhileKeepingCurrentData functionality into replaceBlock to get pre-run and avoid unnecessary flush of user def values if they would be overwritten by the current block data immediately