### PR TITLE
bank loading optimization

### DIFF
--- a/src/connector.cpp
+++ b/src/connector.cpp
@@ -4552,10 +4552,18 @@ void HostConnector::hostClearAndLoadCurrentBank()
         _current.chains[row].playbackId.fill(kMaxHostInstances);
     }
 
-    for (uint8_t pr = 0; pr < NUM_PRESETS_PER_BANK; ++pr)
-        hostLoadPreset(pr);
+    // load, setup, prerun and activate current preset
+    hostLoadPreset(_current.preset);
 
     _host.feature_enable(Host::kFeatureProcessing, Host::kProcessingOnWithFadeIn);
+
+    // load, setup and prerun other presets while already processing current preset
+    for (uint8_t pr = 0; pr < NUM_PRESETS_PER_BANK; ++pr)
+    {
+        if (pr == _current.preset)
+            continue;
+        hostLoadPreset(pr);
+    }
 }
 
 // --------------------------------------------------------------------------------------------------------------------


### PR DESCRIPTION
The addition of pre-run can make bank loading slower. This loading of only active preset before starting audio makes audio switching faster than even before pre-run. The downside is that any front-end waiting for `hostClearAndLoadCurrentBank` to return will be much slower than the audio to react so requires some consideration still before merging.