### PR TITLE
Add a method for waiting for 1 audio cycle

### DIFF
--- a/src/connector.cpp
+++ b/src/connector.cpp
@@ -3499,6 +3499,13 @@ void HostConnector::requestHostUpdates()
 
 // --------------------------------------------------------------------------------------------------------------------
 
+void HostConnector::waitAudioCycle()
+{
+    _host.wait_audio_cycle();
+}
+
+// --------------------------------------------------------------------------------------------------------------------
+
 void HostConnector::enableCpuLoadUpdates(const bool enable)
 {
     _host.feature_enable(Host::kFeatureCpuLoad, enable ? 1 : 0);

--- a/src/connector.hpp
+++ b/src/connector.hpp
@@ -373,6 +373,9 @@ public:
     // request more host updates
     void requestHostUpdates();
 
+    // wait for at least 1 audio cycle to pass
+    void waitAudioCycle();
+
     // ----------------------------------------------------------------------------------------------------------------
     // debug helpers
 

--- a/src/host.cpp
+++ b/src/host.cpp
@@ -1484,6 +1484,11 @@ bool Host::multi_pre_run(const uint8_t reset_value,
     return impl->writeMessageAndWait(msg);
 }
 
+bool Host::wait_audio_cycle()
+{
+    return impl->writeMessageAndWait("wait_audio_cycle");
+}
+
 bool Host::poll_feedback(FeedbackCallback* const callback) const
 {
     return impl->poll(callback);

--- a/src/host.hpp
+++ b/src/host.hpp
@@ -511,6 +511,11 @@ struct Host {
                        const int16_t* instances);
 
    /**
+     * wait for at least 1 audio cycle to pass
+     */
+    bool wait_audio_cycle();
+
+   /**
      * poll feedback port for messages, triggering a callback for each one
      */
     bool poll_feedback(FeedbackCallback* callback) const;


### PR DESCRIPTION
Needed for the new looper, as a way to ensure action triggers are sent separately.
