### PR TITLE
Allow using pre-run for tools

### DIFF
--- a/src/connector.cpp
+++ b/src/connector.cpp
@@ -3794,14 +3794,27 @@ bool HostConnector::transport(const bool rolling, const double beatsPerBar, cons
 
 // --------------------------------------------------------------------------------------------------------------------
 
-bool HostConnector::enableTool(const uint8_t toolIndex, const char* const uri)
+bool HostConnector::enableTool(const uint8_t toolIndex, const char* const uri, const bool prerun)
 {
     mod_log_debug("enableTool(%u, \"%s\")", toolIndex, uri);
     assert(toolIndex < MAX_MOD_HOST_TOOL_INSTANCES);
     assert(toolIndex != 5);
 
-    return isNullURI(uri) ? _host.remove(MAX_MOD_HOST_PLUGIN_INSTANCES + toolIndex)
-                          : _host.add(uri, MAX_MOD_HOST_PLUGIN_INSTANCES + toolIndex);
+    const uint16_t instance = MAX_MOD_HOST_PLUGIN_INSTANCES + toolIndex;
+
+    if (isNullURI(uri))
+        return _host.remove(instance);
+
+    if (prerun)
+    {
+        return (
+            _host.preload(uri, instance) &&
+            _host.pre_run(instance, LV2_KXSTUDIO_PROPERTIES_RESET_FULL, 0, nullptr) &&
+            _host.activate(instance, true)
+        );
+    }
+
+    return _host.add(uri, instance);
 }
 
 // --------------------------------------------------------------------------------------------------------------------

--- a/src/connector.hpp
+++ b/src/connector.hpp
@@ -729,7 +729,7 @@ public:
     // enable a "system tool" lv2 plugin (referenced by its URI)
     // passing null or empty string as the URI means disabling the tool
     // NOTE toolIndex must be < 10 and != 5
-    bool enableTool(uint8_t toolIndex, const char* uri);
+    bool enableTool(uint8_t toolIndex, const char* uri, bool prerun = false);
 
     // connect a tool audio input port to an arbitrary jack output port
     void connectToolAudioInput(uint8_t toolIndex, const char* symbol, const char* jackPort, bool safe = false);


### PR DESCRIPTION
We have the feature now, so we can use it for specific tools that might be heavier than usual.
The mixer and eq come to mind.
