### PR TITLE
Update bindings.value when switching scenes

### DIFF
--- a/src/connector.cpp
+++ b/src/connector.cpp
@@ -2637,6 +2637,60 @@ bool HostConnector::switchScene(const uint8_t scene)
         }
     }
 
+    // update binding values
+    for (uint8_t hwid = 0; hwid < NUM_BINDING_ACTUATORS; ++hwid)
+    {
+        Bindings& bindings(_current.bindings[hwid]);
+
+        if (bindings.parameters.empty())
+            continue;
+
+        bool foundNonBoolean = false;
+
+        for (const ParameterBinding& binding : bindings.parameters)
+        {
+            if (binding.parameterSymbol == ":bypass")
+                continue;
+
+            assert(binding.meta.parameterIndex < NUM_BLOCKS_PER_PRESET);
+
+            const Block& blockdata = _current.chains[binding.row].blocks[binding.block];
+            const Parameter& paramdata = blockdata.parameters[binding.meta.parameterIndex];
+            if ((paramdata.meta.flags & Lv2ParameterToggled) != 0)
+                continue;
+
+            if (binding.min < binding.max)
+                bindings.value = normalized(paramdata.value , binding.min, binding.max);
+            else
+                bindings.value = 1.f - normalized(paramdata.value , binding.max, binding.min);
+
+            foundNonBoolean = true;
+            break;
+        }
+
+        if (! foundNonBoolean)
+        {
+            const ParameterBinding& binding = bindings.parameters.front();
+            const Block& blockdata = _current.chains[binding.row].blocks[binding.block];
+
+            if (binding.parameterSymbol == ":bypass")
+            {
+                bindings.value = blockdata.enabled ? binding.max : binding.min;
+            }
+            else
+            {
+                assert(binding.meta.parameterIndex < NUM_BLOCKS_PER_PRESET);
+
+                const Parameter& paramdata = blockdata.parameters[binding.meta.parameterIndex];
+
+                if (binding.min < binding.max)
+                    bindings.value = normalized(paramdata.value , binding.min, binding.max);
+                else
+                    bindings.value = 1.f - normalized(paramdata.value , binding.max, binding.min);
+            }
+        }
+    }
+
     return true;
 }
 

--- a/src/connector.hpp
+++ b/src/connector.hpp
@@ -266,7 +266,7 @@ struct HostConnector : Host::FeedbackCallback {
         std::string name;
         std::list<ParameterBinding> parameters;
         std::list<PropertyBinding> properties;
-        double value; // NOTE normalized 0-1, updated automatically if single binding
+        double value; // NOTE normalized 0-1, updated automatically if single binding or using scenes
     };
 
     struct ChainRow {


### PR DESCRIPTION
Fixes value display not updating when switching scenes that contain macros.
