### PR TITLE
Handle host disconnections and trigger a callback for it

### DIFF
--- a/src/connector.cpp
+++ b/src/connector.cpp
@@ -426,6 +426,7 @@ static bool safeJsonSave(const nlohmann::json& json, const std::string& filename
 // --------------------------------------------------------------------------------------------------------------------
 
 HostConnector::HostConnector()
+    : _host(this)
 {
     for (uint8_t p = 0; p < NUM_PRESETS_PER_BANK; ++p)
     {
@@ -441,8 +442,9 @@ HostConnector::HostConnector()
 
 // --------------------------------------------------------------------------------------------------------------------
 
-bool HostConnector::reconnect()
+bool HostConnector::reconnect(Callback* const callback)
 {
+    _callback = callback;
     ok = _host.reconnect();
     return ok;
 }
@@ -3550,11 +3552,11 @@ void HostConnector::setBindingValue(const uint8_t hwid,
 
 // --------------------------------------------------------------------------------------------------------------------
 
-void HostConnector::pollHostUpdates(Callback* const callback)
+void HostConnector::pollHostUpdates()
 {
-    _callback = callback;
-    _host.poll_feedback(this);
-    _callback = nullptr;
+    assert(_callback != nullptr);
+
+    _host.poll_feedback();
 }
 
 // --------------------------------------------------------------------------------------------------------------------
@@ -6808,10 +6810,19 @@ void HostConnector::hostPrerunBlockPair(const HostBlockPair& hbp,
 
 // --------------------------------------------------------------------------------------------------------------------
 
+void HostConnector::hostDisconnectedCallback()
+{
+    ok = false;
+
+    if (_callback != nullptr)
+        _callback->hostDisconnectedCallback();
+}
+
+// --------------------------------------------------------------------------------------------------------------------
+
 void HostConnector::hostFeedbackCallback(const HostFeedbackData& data)
 {
-    if (_callback == nullptr)
-        return;
+    assert_return(_callback != nullptr,);
 
     HostCallbackData cdata = {};
 

--- a/src/connector.hpp
+++ b/src/connector.hpp
@@ -29,7 +29,7 @@ enum Lv2ParameterState {
 
 // --------------------------------------------------------------------------------------------------------------------
 
-struct HostConnector : Host::FeedbackCallback {
+struct HostConnector : Host::Callback {
     struct Callback {
         struct Data {
             enum {
@@ -115,6 +115,7 @@ struct HostConnector : Host::FeedbackCallback {
 
         virtual ~Callback() = default;
         virtual void hostConnectorCallback(const Data& data) = 0;
+        virtual void hostDisconnectedCallback() = 0;
     };
 
     enum TemporarySceneState : uint8_t {
@@ -355,7 +356,7 @@ public:
     bool ok = false;
 
     // try to reconnect host if it previously failed
-    bool reconnect();
+    bool reconnect(Callback* callback);
 
     // get last error from host in case something failed
     [[nodiscard]] const std::string& getLastError() const;
@@ -368,7 +369,7 @@ public:
 
     // poll for host updates (e.g. MIDI-mapped parameter changes, tempo changes)
     // NOTE make sure to call `requestHostUpdates()` after handling all updates
-    void pollHostUpdates(Callback* callback);
+    void pollHostUpdates();
 
     // request more host updates
     void requestHostUpdates();
@@ -910,6 +911,9 @@ private:
 
     // multi_prerun for a deactivated block and its pair if exists
     void hostPrerunBlockPair(const HostBlockPair& hbp, uint8_t reset_value, const std::vector<flushed_param>& params);
+
+    // internal disconnected handling
+    void hostDisconnectedCallback() override;
 
     // internal feedback handling, for updating parameter values
     void hostFeedbackCallback(const HostFeedbackData& data) override;

--- a/src/host.cpp
+++ b/src/host.cpp
@@ -185,6 +185,9 @@ struct Host::Impl
 
     void setWriteBlockingAndWait(const bool blocking)
     {
+        if (ipc == nullptr)
+            return;
+
         ipc->setWriteBlockingAndWait(blocking);
     }
 

--- a/src/host.cpp
+++ b/src/host.cpp
@@ -120,15 +120,18 @@ static const char* host_error_code_to_string(const int code)
 
 struct Host::Impl
 {
+    Callback* const callback;
     std::string& last_error;
+
    #ifdef MOD_DEVICE_HOST_PORT
     static constexpr int portNumber = MOD_DEVICE_HOST_PORT;
    #else
     int portNumber = -1;
    #endif
 
-    Impl(std::string& last_error_)
-        : last_error(last_error_)
+    Impl(Callback* const callback_, std::string& last_error_)
+        : callback(callback_),
+          last_error(last_error_)
     {
         reconnect();
     }
@@ -210,23 +213,27 @@ struct Host::Impl
         else
             last_error = ipc->last_error;
 
+        close();
+        callback->hostDisconnectedCallback();
         return false;
     }
 
     // ----------------------------------------------------------------------------------------------------------------
     // feedback port handling
 
-    [[nodiscard]] bool poll(FeedbackCallback* const callback) const
+    [[nodiscard]] bool poll() const
     {
+        assert(ipc != nullptr);
+
         std::string error;
 
-        while (_poll(callback, error)) {}
+        while (_poll(error)) {}
 
         return error.empty();
     }
 
 private:
-    [[nodiscard]] bool _poll(FeedbackCallback* const callback, std::string& error) const
+    [[nodiscard]] bool _poll(std::string& error) const
     {
         uint32_t bytesRead;
         char* const buffer = ipc->readMessage(&bytesRead);
@@ -683,7 +690,7 @@ private:
 
 // --------------------------------------------------------------------------------------------------------------------
 
-Host::Host() : impl(new Impl(last_error)) {}
+Host::Host(Callback* const callback) : impl(new Impl(callback, last_error)) {}
 Host::~Host() { delete impl; }
 
 // --------------------------------------------------------------------------------------------------------------------
@@ -1489,9 +1496,9 @@ bool Host::wait_audio_cycle()
     return impl->writeMessageAndWait("wait_audio_cycle");
 }
 
-bool Host::poll_feedback(FeedbackCallback* const callback) const
+bool Host::poll_feedback() const
 {
-    return impl->poll(callback);
+    return impl->poll();
 }
 
 bool Host::reconnect()

--- a/src/host.hpp
+++ b/src/host.hpp
@@ -70,7 +70,7 @@ struct Host {
         kProcessingOnWithFadeIn = 3,
     };
 
-    struct FeedbackCallback {
+    struct Callback {
         struct Data {
             enum {
                 kFeedbackNullType = 0,
@@ -143,7 +143,8 @@ struct Host {
             };
         };
 
-        virtual ~FeedbackCallback() = default;
+        virtual ~Callback() = default;
+        virtual void hostDisconnectedCallback() = 0;
         virtual void hostFeedbackCallback(const Data& data) = 0;
     };
 
@@ -518,9 +519,9 @@ struct Host {
    /**
      * poll feedback port for messages, triggering a callback for each one
      */
-    bool poll_feedback(FeedbackCallback* callback) const;
+    bool poll_feedback() const;
 
-    Host();
+    Host(Callback* callback);
     ~Host();
 
    /**
@@ -559,4 +560,4 @@ private:
     Impl* const impl;
 };
 
-using HostFeedbackData = Host::FeedbackCallback::Data;
+using HostFeedbackData = Host::Callback::Data;

--- a/src/ipc.cpp
+++ b/src/ipc.cpp
@@ -753,7 +753,7 @@ bool IPC::Impl::SingleSocketTCP::writeMessage(const std::string& message)
 
     while (msgsize > 0)
     {
-        ret = ::send(sockets.outfd, buffer, msgsize, 0);
+        ret = ::send(sockets.outfd, buffer, msgsize, MSG_NOSIGNAL);
         if (ret < 0)
         {
             last_error = "send error";
@@ -911,7 +911,7 @@ bool IPC::Impl::DualSocketTCP::writeMessage(const std::string& message)
 
     while (msgsize > 0)
     {
-        ret = ::send(sockets.out, buffer, msgsize, 0);
+        ret = ::send(sockets.out, buffer, msgsize, MSG_NOSIGNAL);
         if (ret < 0)
         {
             last_error = "send error";

--- a/src/tests.cpp
+++ b/src/tests.cpp
@@ -117,12 +117,17 @@ static QStringList q_jack_port_get_all_connections(jack_client_t* const client, 
     return {};
 }
 
-class HostConnectorTests : public QObject
+class HostConnectorTests : public QObject,
+                           private HostConnector::Callback
 {
     jack_client_t* const client;
     HostProcess& hostProcess;
     HostConnector connector;
     uint retryAttempt = 0;
+
+    // unused
+    void hostConnectorCallback(const Data&) override {}
+    void hostDisconnectedCallback() override {}
 
     // return true if all tests pass
     bool hostReady()
@@ -1795,7 +1800,7 @@ class HostConnectorTests : public QObject
 private slots:
     void reconnect()
     {
-        if (connector.reconnect())
+        if (connector.reconnect(this))
         {
             const bool ok = hostReady();
             hostProcess.terminate();


### PR DESCRIPTION
With this PR we can recover from jack2/mod-host crashes and restarts.

When testing, I found crashes were only happening on write, not on read.
(SIGPIPE signal triggered)

So in theory we only need to catch errors during message writing, and trigger a callback for further handling - which can be some crash recovery or restart, doesnt matter here really.

We need to move a few things around so we can have a callback at an earlier time, but otherwise the disconnected handling on this side in mod-connector is quite simple.