### PR TITLE
Handle host disconnections and trigger a callback for it (version 2)

### DIFF
--- a/examples/lvgl-slider.cpp
+++ b/examples/lvgl-slider.cpp
@@ -56,7 +56,7 @@ static void signal_cb(const int sig) noexcept
 // --------------------------------------------------------------------------------------------------------------------
 // host application details
 
-struct HostApp : Host::FeedbackCallback {
+struct HostApp : Host::Callback {
     Host host;
     bool ok = host.last_error.empty();
     uint32_t lastHostUpdate = 0;

--- a/examples/lvgl-slider.cpp
+++ b/examples/lvgl-slider.cpp
@@ -61,6 +61,11 @@ struct HostApp : Host::Callback {
     bool ok = host.last_error.empty();
     uint32_t lastHostUpdate = 0;
 
+    void hostDisconnectedCallback() override
+    {
+        // unused
+    }
+
     void hostFeedbackCallback(const HostFeedbackData& data) override
     {
         switch (data.type)

--- a/src/connector.cpp
+++ b/src/connector.cpp
@@ -425,8 +425,9 @@ static bool safeJsonSave(const nlohmann::json& json, const std::string& filename
 
 // --------------------------------------------------------------------------------------------------------------------
 
-HostConnector::HostConnector()
-    : _host(this)
+HostConnector::HostConnector(Callback* const callback)
+    : _host(this),
+      _callback(callback)
 {
     for (uint8_t p = 0; p < NUM_PRESETS_PER_BANK; ++p)
     {
@@ -438,6 +439,13 @@ HostConnector::HostConnector()
     resetPreset(_current);
 
     ok = _host.last_error.empty();
+}
+
+// --------------------------------------------------------------------------------------------------------------------
+
+void HostConnector::setCallback(Callback* const callback)
+{
+    _callback = callback;
 }
 
 // --------------------------------------------------------------------------------------------------------------------
@@ -3551,11 +3559,11 @@ void HostConnector::setBindingValue(const uint8_t hwid,
 
 // --------------------------------------------------------------------------------------------------------------------
 
-void HostConnector::pollHostUpdates(Callback* const callback)
+void HostConnector::pollHostUpdates()
 {
-    _callback = callback;
+    assert(_callback != nullptr);
+
     _host.poll_feedback();
-    _callback = nullptr;
 }
 
 // --------------------------------------------------------------------------------------------------------------------

--- a/src/connector.cpp
+++ b/src/connector.cpp
@@ -6820,8 +6820,7 @@ void HostConnector::hostDisconnectedCallback()
 
 void HostConnector::hostFeedbackCallback(const HostFeedbackData& data)
 {
-    if (_callback == nullptr)
-        return;
+    assert_return(_callback != nullptr,);
 
     HostCallbackData cdata = {};
 

--- a/src/connector.cpp
+++ b/src/connector.cpp
@@ -6235,6 +6235,7 @@ void HostConnector::hostPrerunBlockPair(const HostBlockPair& hbp,
 void HostConnector::hostDisconnectedCallback()
 {
     ok = false;
+    _firstboot = true;
 
     if (_callback != nullptr)
         _callback->hostDisconnectedCallback();

--- a/src/connector.cpp
+++ b/src/connector.cpp
@@ -426,6 +426,7 @@ static bool safeJsonSave(const nlohmann::json& json, const std::string& filename
 // --------------------------------------------------------------------------------------------------------------------
 
 HostConnector::HostConnector()
+    : _host(this)
 {
     for (uint8_t p = 0; p < NUM_PRESETS_PER_BANK; ++p)
     {
@@ -3553,7 +3554,7 @@ void HostConnector::setBindingValue(const uint8_t hwid,
 void HostConnector::pollHostUpdates(Callback* const callback)
 {
     _callback = callback;
-    _host.poll_feedback(this);
+    _host.poll_feedback();
     _callback = nullptr;
 }
 

--- a/src/connector.cpp
+++ b/src/connector.cpp
@@ -6808,6 +6808,16 @@ void HostConnector::hostPrerunBlockPair(const HostBlockPair& hbp,
 
 // --------------------------------------------------------------------------------------------------------------------
 
+void HostConnector::hostDisconnectedCallback()
+{
+    ok = false;
+
+    if (_callback != nullptr)
+        _callback->hostDisconnectedCallback();
+}
+
+// --------------------------------------------------------------------------------------------------------------------
+
 void HostConnector::hostFeedbackCallback(const HostFeedbackData& data)
 {
     if (_callback == nullptr)

--- a/src/connector.hpp
+++ b/src/connector.hpp
@@ -115,6 +115,7 @@ struct HostConnector : Host::Callback {
 
         virtual ~Callback() = default;
         virtual void hostConnectorCallback(const Data& data) = 0;
+        virtual void hostDisconnectedCallback() = 0;
     };
 
     enum TemporarySceneState : uint8_t {
@@ -910,6 +911,9 @@ private:
 
     // multi_prerun for a deactivated block and its pair if exists
     void hostPrerunBlockPair(const HostBlockPair& hbp, uint8_t reset_value, const std::vector<flushed_param>& params);
+
+    // internal disconnected handling
+    void hostDisconnectedCallback() override;
 
     // internal feedback handling, for updating parameter values
     void hostFeedbackCallback(const HostFeedbackData& data) override;

--- a/src/connector.hpp
+++ b/src/connector.hpp
@@ -29,7 +29,7 @@ enum Lv2ParameterState {
 
 // --------------------------------------------------------------------------------------------------------------------
 
-struct HostConnector : Host::FeedbackCallback {
+struct HostConnector : Host::Callback {
     struct Callback {
         struct Data {
             enum {

--- a/src/connector.hpp
+++ b/src/connector.hpp
@@ -348,12 +348,15 @@ public:
     std::unordered_map<std::string, std::vector<Lv2Port>> virtualParameters;
 
     // constructor, initializes connection to mod-host and sets `ok` to true if successful
-    HostConnector();
+    HostConnector(Callback* callback = nullptr);
 
     // ----------------------------------------------------------------------------------------------------------------
 
     // whether the host connection is working
     bool ok = false;
+
+    // set callback used for disconnect and feedback events
+    void setCallback(Callback* callback);
 
     // try to reconnect host if it previously failed
     bool reconnect();
@@ -369,9 +372,10 @@ public:
 
     // poll for host updates (e.g. MIDI-mapped parameter changes, tempo changes)
     // NOTE make sure to call `requestHostUpdates()` after handling all updates
-    void pollHostUpdates(Callback* callback);
+    void pollHostUpdates();
 
     // request more host updates
+    // NOTE make sure to call `setCallback` beforehand
     void requestHostUpdates();
 
     // wait for at least 1 audio cycle to pass

--- a/src/host.cpp
+++ b/src/host.cpp
@@ -206,7 +206,8 @@ struct Host::Impl
             return false;
         }
 
-        if (ipc->writeMessage(message, respType, resp))
+        const IPC::WriteError error = ipc->writeMessage(message, respType, resp);
+        if (error == IPC::kWriteSuccess)
             return true;
 
         if (resp != nullptr && resp->code < 0)
@@ -214,8 +215,12 @@ struct Host::Impl
         else
             last_error = ipc->last_error;
 
-        close();
-        callback->hostDisconnectedCallback();
+        if (error == IPC::kWriteErrorDisconnected)
+        {
+            close();
+            callback->hostDisconnectedCallback();
+        }
+
         return false;
     }
 

--- a/src/host.cpp
+++ b/src/host.cpp
@@ -182,7 +182,8 @@ struct Host::Impl
 
     void setWriteBlockingAndWait(const bool blocking)
     {
-        ipc->setWriteBlockingAndWait(blocking);
+        if (ipc != nullptr)
+            ipc->setWriteBlockingAndWait(blocking);
     }
 
     bool writeMessageAndWait(const std::string& message,

--- a/src/host.cpp
+++ b/src/host.cpp
@@ -216,7 +216,7 @@ struct Host::Impl
     // ----------------------------------------------------------------------------------------------------------------
     // feedback port handling
 
-    [[nodiscard]] bool poll(FeedbackCallback* const callback) const
+    [[nodiscard]] bool poll(Callback* const callback) const
     {
         std::string error;
 
@@ -226,7 +226,7 @@ struct Host::Impl
     }
 
 private:
-    [[nodiscard]] bool _poll(FeedbackCallback* const callback, std::string& error) const
+    [[nodiscard]] bool _poll(Callback* const callback, std::string& error) const
     {
         uint32_t bytesRead;
         char* const buffer = ipc->readMessage(&bytesRead);
@@ -1366,7 +1366,7 @@ bool Host::wait_audio_cycle()
     return impl->writeMessageAndWait("wait_audio_cycle");
 }
 
-bool Host::poll_feedback(FeedbackCallback* const callback) const
+bool Host::poll_feedback(Callback* const callback) const
 {
     return impl->poll(callback);
 }

--- a/src/host.cpp
+++ b/src/host.cpp
@@ -120,15 +120,18 @@ static const char* host_error_code_to_string(const int code)
 
 struct Host::Impl
 {
+    Callback* const callback;
     std::string& last_error;
+
    #ifdef MOD_DEVICE_HOST_PORT
     static constexpr int portNumber = MOD_DEVICE_HOST_PORT;
    #else
     int portNumber = -1;
    #endif
 
-    Impl(std::string& last_error_)
-        : last_error(last_error_)
+    Impl(Callback* const callback_, std::string& last_error_)
+        : callback(callback_),
+          last_error(last_error_)
     {
         reconnect();
     }
@@ -217,17 +220,19 @@ struct Host::Impl
     // ----------------------------------------------------------------------------------------------------------------
     // feedback port handling
 
-    [[nodiscard]] bool poll(Callback* const callback) const
+    [[nodiscard]] bool poll() const
     {
+        assert(ipc != nullptr);
+
         std::string error;
 
-        while (_poll(callback, error)) {}
+        while (_poll(error)) {}
 
         return error.empty();
     }
 
 private:
-    [[nodiscard]] bool _poll(Callback* const callback, std::string& error) const
+    [[nodiscard]] bool _poll(std::string& error) const
     {
         uint32_t bytesRead;
         char* const buffer = ipc->readMessage(&bytesRead);
@@ -684,7 +689,7 @@ private:
 
 // --------------------------------------------------------------------------------------------------------------------
 
-Host::Host() : impl(new Impl(last_error)) {}
+Host::Host(Callback* const callback) : impl(new Impl(callback, last_error)) {}
 Host::~Host() { delete impl; }
 
 // --------------------------------------------------------------------------------------------------------------------
@@ -1367,9 +1372,9 @@ bool Host::wait_audio_cycle()
     return impl->writeMessageAndWait("wait_audio_cycle");
 }
 
-bool Host::poll_feedback(Callback* const callback) const
+bool Host::poll_feedback() const
 {
-    return impl->poll(callback);
+    return impl->poll();
 }
 
 bool Host::reconnect()

--- a/src/host.cpp
+++ b/src/host.cpp
@@ -214,6 +214,8 @@ struct Host::Impl
         else
             last_error = ipc->last_error;
 
+        close();
+        callback->hostDisconnectedCallback();
         return false;
     }
 

--- a/src/host.hpp
+++ b/src/host.hpp
@@ -139,6 +139,7 @@ struct Host {
         };
 
         virtual ~Callback() = default;
+        virtual void hostDisconnectedCallback() = 0;
         virtual void hostFeedbackCallback(const Data& data) = 0;
     };
 

--- a/src/host.hpp
+++ b/src/host.hpp
@@ -65,7 +65,7 @@ struct Host {
         kProcessingOnWithFadeIn = 3,
     };
 
-    struct FeedbackCallback {
+    struct Callback {
         struct Data {
             enum {
                 kFeedbackNullType = 0,
@@ -138,7 +138,7 @@ struct Host {
             };
         };
 
-        virtual ~FeedbackCallback() = default;
+        virtual ~Callback() = default;
         virtual void hostFeedbackCallback(const Data& data) = 0;
     };
 
@@ -445,7 +445,7 @@ struct Host {
    /**
      * poll feedback port for messages, triggering a callback for each one
      */
-    bool poll_feedback(FeedbackCallback* callback) const;
+    bool poll_feedback(Callback* callback) const;
 
     Host();
     ~Host();
@@ -486,4 +486,4 @@ private:
     Impl* const impl;
 };
 
-using HostFeedbackData = Host::FeedbackCallback::Data;
+using HostFeedbackData = Host::Callback::Data;

--- a/src/host.hpp
+++ b/src/host.hpp
@@ -446,9 +446,9 @@ struct Host {
    /**
      * poll feedback port for messages, triggering a callback for each one
      */
-    bool poll_feedback(Callback* callback) const;
+    bool poll_feedback() const;
 
-    Host();
+    Host(Callback* callback);
     ~Host();
 
    /**

--- a/src/ipc.cpp
+++ b/src/ipc.cpp
@@ -247,7 +247,7 @@ struct IPC::Impl
         }
     }
 
-    bool writeMessage(const std::string& message, const ResponseType respType, Response* const resp)
+    IPC::WriteError writeMessage(const std::string& message, const ResponseType respType, Response* const resp)
     {
        #ifndef NDEBUG
         if (resp != nullptr)
@@ -278,13 +278,13 @@ struct IPC::Impl
                     break;
                 }
             }
-            return true;
+            return kWriteSuccess;
         }
 
         if (! iface->writeMessage(message))
         {
             mod_log_warn("iface->writeMessage() error: %s", last_error.c_str());
-            return false;
+            return kWriteErrorDisconnected;
         }
 
         // retrieve response
@@ -338,7 +338,7 @@ struct IPC::Impl
             if (! last_error.empty())
             {
                 mod_log_warn("iface->readResponseByte() error: %s", last_error.c_str());
-                return false;
+                return kWriteErrorDisconnected;
             }
 
            #if 0 // ndef NDEBUG
@@ -355,13 +355,13 @@ struct IPC::Impl
                     resp->code = 0;
                     resp->data.s = buffer;
                 }
-                return true;
+                return kWriteSuccess;
             }
 
             if (buffer[0] == '\0')
             {
                 last_error = "reply is empty";
-                return false;
+                return kWriteErrorBadReply;
             }
 
             char* respbuffer;
@@ -371,7 +371,7 @@ struct IPC::Impl
                 if (*respbuffer == '\0')
                 {
                     last_error = "mod-ui reply is incomplete (less than 3 characters)";
-                    return false;
+                    return kWriteErrorBadReply;
                 }
             }
             else if (std::strncmp(buffer, "resp ", 5) == 0)
@@ -380,13 +380,13 @@ struct IPC::Impl
                 if (*respbuffer == '\0')
                 {
                     last_error = "mod-host reply is incomplete (less than 6 characters)";
-                    return false;
+                    return kWriteErrorBadReply;
                 }
             }
             else
             {
                 last_error = "reply is malformed (missing 'r' or 'resp' prefix)";
-                return false;
+                return kWriteErrorBadReply;
             }
 
             const char* respdata;
@@ -403,15 +403,18 @@ struct IPC::Impl
             // parse response error code
             const int respcode = std::atoi(respbuffer);
 
+            if (resp != nullptr)
+            {
+                *resp = {};
+                resp->code = respcode;
+            }
+
             if (respcode < 0)
-                return false;
+                return kWriteErrorBadReply;
 
             // stop here if not wanting response data
             if (resp == nullptr)
-                return true;
-
-            *resp = {};
-            resp->code = respcode;
+                return kWriteSuccess;
 
             switch (respType)
             {
@@ -431,15 +434,15 @@ struct IPC::Impl
             }
         }
 
-        return true;
+        return kWriteSuccess;
     }
 
-    bool writeMessageWithoutReply(const std::string& message)
+    IPC::WriteError writeMessageWithoutReply(const std::string& message)
     {
         if (dummyDevMode)
-            return true;
+            return kWriteSuccess;
 
-        return iface->writeMessage(message);
+        return iface->writeMessage(message) ? kWriteSuccess : kWriteErrorDisconnected;
     }
 
 private:
@@ -1047,12 +1050,12 @@ void IPC::setWriteBlockingAndWait(const bool blocking)
     impl->setWriteBlockingAndWait(blocking);
 }
 
-bool IPC::writeMessage(const std::string& message, const ResponseType respType, Response* const resp)
+IPC::WriteError IPC::writeMessage(const std::string& message, const ResponseType respType, Response* const resp)
 {
     return impl->writeMessage(message, respType, resp);
 }
 
-bool IPC::writeMessageWithoutReply(const std::string& message)
+IPC::WriteError IPC::writeMessageWithoutReply(const std::string& message)
 {
     return impl->writeMessageWithoutReply(message);
 }

--- a/src/ipc.cpp
+++ b/src/ipc.cpp
@@ -753,7 +753,7 @@ bool IPC::Impl::SingleSocketTCP::writeMessage(const std::string& message)
 
     while (msgsize > 0)
     {
-        ret = ::send(sockets.outfd, buffer, msgsize, 0);
+        ret = ::send(sockets.outfd, buffer, msgsize, MSG_NOSIGNAL);
         if (ret < 0)
         {
             last_error = "send error";
@@ -911,7 +911,7 @@ bool IPC::Impl::DualSocketTCP::writeMessage(const std::string& message)
 
     while (msgsize > 0)
     {
-        ret = ::send(sockets.out, buffer, msgsize, 0);
+        ret = ::send(sockets.out, buffer, msgsize, MSG_NOSIGNAL);
         if (ret < 0)
         {
             last_error = "send error";

--- a/src/ipc.hpp
+++ b/src/ipc.hpp
@@ -19,6 +19,15 @@ struct IPC
     };
 
     /**
+     * type of write error.
+     */
+    enum WriteError {
+        kWriteSuccess,
+        kWriteErrorBadReply,
+        kWriteErrorDisconnected,
+    };
+
+    /**
      * message response with error code and optional data.
      * there is no generic handling, response is specific to the message being sent.
      */
@@ -73,12 +82,14 @@ struct IPC
     /**
      * write a message and potentially fetch remote response.
      */
-    bool writeMessage(const std::string& message, ResponseType respType = kResponseNone, Response* resp = nullptr);
+    WriteError writeMessage(const std::string& message,
+                            ResponseType respType = kResponseNone,
+                            Response* resp = nullptr);
 
     /**
      * write a message without a reply, typically used for replies themselves.
      */
-    bool writeMessageWithoutReply(const std::string& message);
+    WriteError writeMessageWithoutReply(const std::string& message);
 
 protected:
     IPC();

--- a/src/tests.cpp
+++ b/src/tests.cpp
@@ -1824,6 +1824,8 @@ public:
         : client(c),
           hostProcess(hostProc)
     {
+        connector.setCallback(this);
+
         QDir::current().mkdir(PRESETFILEPATH);
 
         mod_log_info("Connecting to host...");

--- a/src/tests.cpp
+++ b/src/tests.cpp
@@ -127,6 +127,7 @@ class HostConnectorTests : public QObject,
 
     // unused
     void hostConnectorCallback(const Data&) override {}
+    void hostDisconnectedCallback() override {}
 
     // return true if all tests pass
     bool hostReady()

--- a/src/tests.cpp
+++ b/src/tests.cpp
@@ -117,12 +117,16 @@ static QStringList q_jack_port_get_all_connections(jack_client_t* const client, 
     return {};
 }
 
-class HostConnectorTests : public QObject
+class HostConnectorTests : public QObject,
+                           private HostConnector::Callback
 {
     jack_client_t* const client;
     HostProcess& hostProcess;
     HostConnector connector;
     uint retryAttempt = 0;
+
+    // unused
+    void hostConnectorCallback(const Data&) override {}
 
     // return true if all tests pass
     bool hostReady()


### PR DESCRIPTION
Copied from #44:

With this PR we can recover from jack2/mod-host crashes and restarts.

When testing, I found crashes were only happening on write, not on read.
(SIGPIPE signal triggered)

So in theory we only need to catch errors during message writing, and trigger a callback for further handling - which can be some crash recovery or restart, doesnt matter here really.

We need to move a few things around so we can have a callback at an earlier time, but otherwise the disconnected handling on this side in mod-connector is quite simple.

Changes from v1:
- fix error handling to differentiate between host error vs disconnected (fixes tests)
- update lvgl-slider demo to match API changes
- do not tie hostconnector callback to `reconnect` call, use a separate function for setting callback
