### PR TITLE
Prevent expensive copies of connector data

### DIFF
--- a/src/connector.cpp
+++ b/src/connector.cpp
@@ -1620,6 +1620,9 @@ bool HostConnector::reorderBlock(const uint8_t row, const uint8_t orig, const ui
                         .meta = {
                             .block = blockdata,
                             .parameterIndex = parameterIndex,
+                           #ifndef _DARKGLASS_DEVICE_PABLITO
+                            .isBypassParameter = false,
+                           #endif
                             .parameter = blockdata.parameters[parameterIndex],
                         },
                     });
@@ -2391,23 +2394,82 @@ bool HostConnector::swapBlockRow(const uint8_t row,
 
         _mapper.swapBlocks(_current.preset, row, block, emptyRow, emptyBlock);
 
-        for (Bindings& bindings : _current.bindings)
+        const Block& blockdata = _current.chains[emptyRow].blocks[emptyBlock];
+
+        for (uint8_t hwid = 0; hwid < NUM_BINDING_ACTUATORS; ++hwid)
         {
-            for (ParameterBinding& bindingdata : bindings.parameters)
+            if (std::list<ParameterBinding>& bindings(_current.bindings[hwid].parameters); ! bindings.empty())
             {
-                if (bindingdata.row == row && bindingdata.block == block)
+                for (ParameterBindingIterator it = bindings.begin(), end = bindings.end(); it != end; ++it)
                 {
-                    bindingdata.row = emptyRow;
-                    bindingdata.block = emptyBlock;
+                    if (it->row != row || it->block != block)
+                        continue;
+
+                    const float min = it->min;
+                    const float max = it->max;
+
+                    if (it->meta.isBypass)
+                    {
+                        it = bindings.erase(it);
+                        bindings.insert(it, {
+                            .row = emptyRow,
+                            .block = emptyBlock,
+                            .min = min,
+                            .max = max,
+                            .parameterSymbol = ":bypass",
+                            .meta = {
+                                .block = blockdata,
+                                .parameterIndex = 0,
+                                .isBypass = true,
+                            },
+                        });
+                    }
+                    else
+                    {
+                        const uint8_t parameterIndex = it->meta.parameterIndex;
+                        const std::string parameterSymbol = it->parameterSymbol;
+
+                        it = bindings.erase(it);
+                        bindings.insert(it, {
+                            .row = emptyRow,
+                            .block = emptyBlock,
+                            .min = min,
+                            .max = max,
+                            .parameterSymbol = parameterSymbol,
+                            .meta = {
+                                .block = blockdata,
+                                .parameterIndex = parameterIndex,
+                               #ifndef _DARKGLASS_DEVICE_PABLITO
+                                .isBypassParameter = false,
+                               #endif
+                                .parameter = blockdata.parameters[parameterIndex],
+                            },
+                        });
+                    }
                 }
             }
 
-            for (PropertyBinding& bindingdata : bindings.properties)
+            if (std::list<PropertyBinding>& bindings(_current.bindings[hwid].properties); ! bindings.empty())
             {
-                if (bindingdata.row == row && bindingdata.block == block)
+                for (PropertyBindingIterator it = bindings.begin(), end = bindings.end(); it != end; ++it)
                 {
-                    bindingdata.row = emptyRow;
-                    bindingdata.block = emptyBlock;
+                    if (it->row != row || it->block != block)
+                        continue;
+
+                    const uint8_t propertyIndex = it->meta.propertyIndex;
+                    const std::string propertyURI = it->propertyURI;
+
+                    it = bindings.erase(it);
+                    bindings.insert(it, {
+                        .row = emptyRow,
+                        .block = emptyBlock,
+                        .propertyURI = propertyURI,
+                        .meta = {
+                            .propertyIndex = propertyIndex,
+                            .block = blockdata,
+                            .property = blockdata.properties[propertyIndex],
+                        },
+                    });
                 }
             }
         }
@@ -2947,6 +3009,9 @@ bool HostConnector::addBlockParameterBinding(const uint8_t hwid,
         .meta = {
             .block = blockdata,
             .parameterIndex = paramIndex,
+           #ifndef _DARKGLASS_DEVICE_PABLITO
+            .isBypassParameter = false,
+           #endif
             .parameter = paramdata,
         },
     });
@@ -3435,6 +3500,9 @@ bool HostConnector::replaceBlockParameterBinding(const uint8_t hwid,
             .meta = {
                 .block = blockdataB,
                 .parameterIndex = paramIndexB,
+               #ifndef _DARKGLASS_DEVICE_PABLITO
+                .isBypassParameter = false,
+               #endif
                 .parameter = paramdataB,
             },
         });
@@ -5962,6 +6030,9 @@ void HostConnector::jsonPresetLoad(Preset& presetdata, const nlohmann::json& jpr
                                 .meta = {
                                     .block = blockdata,
                                     .parameterIndex = p,
+                                   #ifndef _DARKGLASS_DEVICE_PABLITO
+                                    .isBypassParameter = false,
+                                   #endif
                                     .parameter = paramdata,
                                 },
                             });

--- a/src/connector.cpp
+++ b/src/connector.cpp
@@ -425,15 +425,41 @@ static bool safeJsonSave(const nlohmann::json& json, const std::string& filename
 
 // --------------------------------------------------------------------------------------------------------------------
 
+void HostConnector::Bindings::copy(const Bindings& other)
+{
+    name = other.name;
+    value = other.value;
+
+    const auto copyList = [](auto& mylist, const auto& otherlist){
+        mylist.clear();
+        for (const auto& item : otherlist)
+            mylist.push_back(item);
+    };
+
+    copyList(parameters, other.parameters);
+    copyList(properties, other.properties);
+}
+
+void HostConnector::Preset::copy(const Preset& other)
+{
+    scene = other.scene;
+    name = other.name;
+    filename = other.filename;
+    for (uint8_t i = 0; i < NUM_BINDING_ACTUATORS; ++i)
+        bindings[i].copy(other.bindings[i]);
+    background = other.background;
+    sceneNames = other.sceneNames;
+    uuid = other.uuid;
+    chains = other.chains;
+}
+
+// --------------------------------------------------------------------------------------------------------------------
+
 HostConnector::HostConnector()
 {
     for (uint8_t p = 0; p < NUM_PRESETS_PER_BANK; ++p)
-    {
-        allocPreset(_presets[p]);
         resetPreset(_presets[p]);
-    }
 
-    allocPreset(_current);
     resetPreset(_current);
 
     ok = _host.last_error.empty();
@@ -847,7 +873,7 @@ void HostConnector::loadBankFromPresetFiles(const std::array<std::string, NUM_PR
     }
 
     // create current preset data from selected initial preset
-    static_cast<Preset&>(_current) = _presets[initialPresetToLoad];
+    static_cast<Preset&>(_current).copy(_presets[initialPresetToLoad]);
     _current.preset = initialPresetToLoad;
     _current.defaultScene = _current.scene;
 
@@ -915,7 +941,7 @@ bool HostConnector::loadCurrentPresetFromFile(const char* const filename, const 
     _current.filename = filename;
 
     if (replaceDefault)
-        _presets[_current.preset] = _current;
+        _presets[_current.preset].copy(_current);
 
     // load new preset
     hostLoadPreset(_current.preset);
@@ -937,7 +963,7 @@ bool HostConnector::preloadPresetFromFile(const uint8_t preset, const char* cons
 
     // load preset data
     Preset presetdata;
-    allocPreset(presetdata, false);
+    resetPresetPorts(presetdata, false);
 
     if (loaded)
         jsonPresetLoad(presetdata, j);
@@ -966,7 +992,8 @@ bool HostConnector::preloadPresetFromFile(const uint8_t preset, const char* cons
     }
 
     // assign and preload new preset
-    _presets[preset] = presetdata;
+    // optimization: use swap instead of copy as we dont need `presetdata` after this
+    std::swap(_presets[preset], presetdata);
 
     {
         const Host::NonBlockingScope hnbs(_host);
@@ -1074,7 +1101,7 @@ bool HostConnector::saveCurrentPresetToFile(const char* const filename)
     }
 
     // copy current data into preset data
-    _presets[_current.preset] = static_cast<Preset&>(_current);
+    _presets[_current.preset].copy(static_cast<Preset&>(_current));
 
     jsonPresetSave(_current, j["preset"]);
 
@@ -2003,10 +2030,10 @@ bool HostConnector::replaceBlockWhileKeepingCurrentData(const uint8_t row, const
     assert(block < NUM_BLOCKS_PER_PRESET);
     assert(!isNullURI(uri));
 
-    const Block blockcopy = _current.chains[row].blocks[block];
-    assert(!isNullURI(blockcopy.uri));
+    const Block& blockdata = _current.chains[row].blocks[block];
+    assert(!isNullURI(blockdata.uri));
 
-    if (blockcopy.uri == uri)
+    if (blockdata.uri == uri)
     {
         mod_log_warn("replaceBlockWhileKeepingCurrentData(%u, %u, \"%s\") - same uri, rejected", row, block, uri);
         return false;
@@ -2323,16 +2350,19 @@ bool HostConnector::switchPreset(const uint8_t preset)
     if (_current.preset == preset)
         return false;
 
-    // store old active preset in memory before doing anything
-    const Current old = _current;
+    // store previous active preset in memory before doing anything
+    const uint8_t prevPreset = _current.preset;
+    const uint8_t prevNumLoadedPlugins = _current.numLoadedPlugins;
+    Preset prev;
+    prev.copy(_current);
 
     // copy new preset to current data
-    static_cast<Preset&>(_current) = _presets[preset];
+    static_cast<Preset&>(_current).copy(_presets[preset]);
     _current.preset = preset;
     _current.defaultScene = _current.scene;
 
-    // switch old preset with new one
-    hostSwitchPreset(old);
+    // switch previous preset with new one
+    hostSwitchPreset(prev, prevPreset, prevNumLoadedPlugins);
     return true;
 }
 
@@ -2757,7 +2787,18 @@ bool HostConnector::addBlockBinding(const uint8_t hwid, const uint8_t row, const
         _current.bindings[hwid].name = getNextMacroBindingName(_current);
     }
 
-    _current.bindings[hwid].parameters.push_back({ row, block, 0.f, 1.f, ":bypass", { 0 } });
+    _current.bindings[hwid].parameters.push_back({
+        .row = row,
+        .block = block,
+        .min = 0.f,
+        .max = 1.f,
+        .parameterSymbol = ":bypass",
+        .meta = {
+            .block = blockdata,
+            .parameterIndex = 0,
+            .isBypass = true,
+        }
+    });
     _current.dirty = true;
     return true;
 }
@@ -2812,7 +2853,16 @@ bool HostConnector::addBlockParameterBinding(const uint8_t hwid,
     }
 
     _current.bindings[hwid].parameters.push_back({
-        row, block, paramdata.meta.min, paramdata.meta.max, paramdata.symbol, { paramIndex }
+        .row = row,
+        .block = block,
+        .min = paramdata.meta.min,
+        .max = paramdata.meta.max,
+        .parameterSymbol = paramdata.symbol,
+        .meta = {
+            .block = blockdata,
+            .parameterIndex = paramIndex,
+            .parameter = paramdata,
+        },
     });
     _current.dirty = true;
     return true;
@@ -2871,7 +2921,7 @@ bool HostConnector::addBlockPropertyBinding(const uint8_t hwid,
         _current.bindings[hwid].name = getNextMacroBindingName(_current);
     }
 
-    _current.bindings[hwid].properties.push_back({ row, block, propdata.uri, { propIndex } });
+    _current.bindings[hwid].properties.push_back({ row, block, propdata.uri, { propIndex, blockdata, propdata } });
     _current.dirty = true;
     return true;
 }
@@ -3191,8 +3241,22 @@ bool HostConnector::replaceBlockBinding(const uint8_t hwid,
         if (it->parameterSymbol != ":bypass")
             continue;
 
-        it->row = rowB;
-        it->block = blockB;
+        const float min = it->min;
+        const float max = it->max;
+
+        it = bindings.erase(it);
+        bindings.insert(it, {
+            .row = rowB,
+            .block = blockB,
+            .min = min,
+            .max = max,
+            .parameterSymbol = ":bypass",
+            .meta = {
+                .block = blockdataB,
+                .parameterIndex = 0,
+                .isBypass = true,
+            },
+        });
 
         blockdata.meta.enable.hwbinding = UINT8_MAX;
         blockdataB.meta.enable.hwbinding = hwid;
@@ -3275,12 +3339,19 @@ bool HostConnector::replaceBlockParameterBinding(const uint8_t hwid,
         if (it->meta.parameterIndex != paramIndex)
             continue;
 
-        it->row = rowB;
-        it->block = blockB;
-        it->meta.parameterIndex = paramIndexB;
-        it->min = paramdataB.meta.min;
-        it->max = paramdataB.meta.max;
-        it->parameterSymbol = paramdataB.symbol;
+        it = bindings.erase(it);
+        bindings.insert(it, {
+            .row = rowB,
+            .block = blockB,
+            .min = paramdataB.meta.min,
+            .max = paramdataB.meta.max,
+            .parameterSymbol = paramdataB.symbol,
+            .meta = {
+                .block = blockdataB,
+                .parameterIndex = paramIndexB,
+                .parameter = paramdataB,
+            },
+        });
 
         paramdata.meta.hwbinding = UINT8_MAX;
         paramdataB.meta.hwbinding = hwid;
@@ -3364,10 +3435,17 @@ bool HostConnector::replaceBlockPropertyBinding(const uint8_t hwid,
         if (it->meta.propertyIndex != propIndex)
             continue;
 
-        it->row = rowB;
-        it->block = blockB;
-        it->meta.propertyIndex = propIndexB;
-        it->propertyURI = propdataB.uri;
+        it = bindings.erase(it);
+        bindings.insert(it, {
+            .row = rowB,
+            .block = blockB,
+            .propertyURI = propdataB.uri,
+            .meta = {
+                .propertyIndex = propIndexB,
+                .block = blockdataB,
+                .property = propdataB,
+            },
+        });
 
         propdata.meta.hwbinding = UINT8_MAX;
         propdataB.meta.hwbinding = hwid;
@@ -5657,7 +5735,8 @@ void HostConnector::jsonPresetLoad(Preset& presetdata, const nlohmann::json& jpr
                     std::list<ParameterBinding> parameters;
                     std::string symbol;
                     int block, row;
-                    float min, max;
+                    float min = 0.f;
+                    float max = 1.f;
 
                     for (const auto& jbindingparam : jbindingparams)
                     {
@@ -5746,11 +5825,13 @@ void HostConnector::jsonPresetLoad(Preset& presetdata, const nlohmann::json& jpr
                             parameters.push_back({
                                 .row = static_cast<uint8_t>(row - 1),
                                 .block = static_cast<uint8_t>(block - 1),
-                                .min = hasRanges ? min : 0.f,
-                                .max = hasRanges ? max : 1.f,
+                                .min = min,
+                                .max = max,
                                 .parameterSymbol = ":bypass",
                                 .meta = {
+                                    .block = blockdata,
                                     .parameterIndex = 0,
+                                    .isBypass = true,
                                 },
                             });
                             continue;
@@ -5793,7 +5874,9 @@ void HostConnector::jsonPresetLoad(Preset& presetdata, const nlohmann::json& jpr
                                 .max = max,
                                 .parameterSymbol = symbol,
                                 .meta = {
+                                    .block = blockdata,
                                     .parameterIndex = p,
+                                    .parameter = paramdata,
                                 },
                             });
                             found = true;
@@ -5804,7 +5887,7 @@ void HostConnector::jsonPresetLoad(Preset& presetdata, const nlohmann::json& jpr
                             mod_log_warn("jsonPresetLoad(): binding parameter %s not found in plugin", symbol.c_str());
                     }
 
-                    bindings.parameters = parameters;
+                    std::swap(bindings.parameters, parameters);
                 }
                 else
                 {
@@ -5902,13 +5985,15 @@ void HostConnector::jsonPresetLoad(Preset& presetdata, const nlohmann::json& jpr
                                 .propertyURI = uri,
                                 .meta = {
                                     .propertyIndex = p,
+                                    .block = blockdata,
+                                    .property = propdata,
                                 },
                             });
                             break;
                         }
                     }
 
-                    bindings.properties = properties;
+                    std::swap(bindings.properties, properties);
                 }
                 else
                 {
@@ -6054,7 +6139,7 @@ void HostConnector::jsonPresetLoad(Preset& presetdata, const nlohmann::json& jpr
 
 // --------------------------------------------------------------------------------------------------------------------
 
-void HostConnector::jsonPresetSave(const Preset& presetdata, nlohmann::json& jpreset) const
+void HostConnector::jsonPresetSave(const Preset& presetdata, nlohmann::json& jpreset)
 {
     jpreset = nlohmann::json::object({
         { "bindings", nlohmann::json::object({}) },
@@ -6380,11 +6465,11 @@ void HostConnector::hostLoadPreset(const uint8_t preset)
 
 // --------------------------------------------------------------------------------------------------------------------
 
-void HostConnector::hostSwitchPreset(const Current& prev)
+void HostConnector::hostSwitchPreset(const Preset& prev, const uint8_t prevPreset, const uint8_t prevNumLoadedPlugins)
 {
     mod_log_debug("hostSwitchPreset(...)");
 
-    if (_current.preset == prev.preset) {
+    if (_current.preset == prevPreset) {
         assert(_current.numLoadedPlugins == 0);
     }
 
@@ -6405,7 +6490,7 @@ void HostConnector::hostSwitchPreset(const Current& prev)
 
         // step 1: disconnect and deactivate all plugins in prev preset
         // NOTE not removing plugins, done after processing is reenabled
-        if (prev.numLoadedPlugins == 0)
+        if (prevNumLoadedPlugins == 0)
         {
             std::memset(oldloaded, 0, sizeof(oldloaded));
             hostDisconnectChainEndpoints(0);
@@ -6423,7 +6508,7 @@ void HostConnector::hostSwitchPreset(const Current& prev)
                     if (! (oldloaded[row][bl] = !isNullBlock(blockdata)))
                         continue;
 
-                    const HostBlockPair hbp = _mapper.get(prev.preset, row, bl);
+                    const HostBlockPair hbp = _mapper.get(prevPreset, row, bl);
                     hostDisconnectAllBlockInputs(blockdata, hbp);
                     hostDisconnectAllBlockOutputs(blockdata, hbp);
 
@@ -6528,8 +6613,8 @@ void HostConnector::hostSwitchPreset(const Current& prev)
 
     // scope for preloading default preset state and copying current port state cache
     {
-        const Preset& defaults = _presets[prev.preset];
-        Preset& inactivatedPreset = _presets[prev.preset];
+        const Preset& defaults = _presets[prevPreset];
+        Preset& inactivatedPreset = _presets[prevPreset];
         // bool defloaded[NUM_BLOCKS_PER_PRESET];
 
         const Host::NonBlockingScope hnbs(_host);
@@ -6549,7 +6634,7 @@ void HostConnector::hostSwitchPreset(const Current& prev)
                     if (isNullBlock(defblockdata))
                         continue;
 
-                    const HostBlockPair hbp = _mapper.get(prev.preset, row, bl);
+                    const HostBlockPair hbp = _mapper.get(prevPreset, row, bl);
                     assert_continue(hbp.id != kMaxHostInstances);
 
                     if (defblockdata.meta.enable.changesNotSavedToPreset)
@@ -6620,7 +6705,7 @@ void HostConnector::hostSwitchPreset(const Current& prev)
                 // different plugin, unload old one if there is any
                 if (oldloaded[row][bl])
                 {
-                    if (const HostBlockPair hbp = _mapper.remove(prev.preset, row, bl); hbp.id != kMaxHostInstances)
+                    if (const HostBlockPair hbp = _mapper.remove(prevPreset, row, bl); hbp.id != kMaxHostInstances)
                         hostRemoveBlockPair(hbp);
                 }
 
@@ -6629,7 +6714,7 @@ void HostConnector::hostSwitchPreset(const Current& prev)
                     continue;
 
                 // otherwise load default plugin
-                HostBlockPair hbp = { _mapper.add(prev.preset, row, bl), kMaxHostInstances };
+                HostBlockPair hbp = { _mapper.add(prevPreset, row, bl), kMaxHostInstances };
                 _host.preload(defblockdata.uri.c_str(), hbp.id);
 
                 if (!defblockdata.enabled)
@@ -6672,7 +6757,7 @@ void HostConnector::hostSwitchPreset(const Current& prev)
 
         // ensure necessary dual mono blocks are added
         // FIXME? this makes unnecessary connections for the non-acive preset?
-        hostEnsureStereoChain(prev.preset, 0);
+        hostEnsureStereoChain(prevPreset, 0);
     }
 }
 
@@ -7384,7 +7469,7 @@ void HostConnector::initBlock(HostConnector::Block& blockdata,
 
 // --------------------------------------------------------------------------------------------------------------------
 
-void HostConnector::resetBlock(Block& blockdata) const
+void HostConnector::resetBlock(Block& blockdata)
 {
     blockdata.enabled = false;
     blockdata.uri.clear();
@@ -7419,47 +7504,9 @@ void HostConnector::resetBlock(Block& blockdata) const
     }
 }
 
-void HostConnector::allocBlock(Block& blockdata) const
-{
-    blockdata.parameters.resize(MAX_PARAMS_PER_BLOCK);
-    blockdata.properties.resize(MAX_PARAMS_PER_BLOCK);
-
-    for (uint8_t s = 0; s < NUM_SCENES_PER_PRESET; ++s)
-    {
-        blockdata.sceneValues[s].parameters.resize(MAX_PARAMS_PER_BLOCK);
-        blockdata.sceneValues[s].properties.resize(MAX_PARAMS_PER_BLOCK);
-        blockdata.lastSavedSceneValues[s].parameters.resize(MAX_PARAMS_PER_BLOCK);
-        blockdata.lastSavedSceneValues[s].properties.resize(MAX_PARAMS_PER_BLOCK);
-    }
-}
-
 // --------------------------------------------------------------------------------------------------------------------
 
-void HostConnector::allocPreset(Preset& preset, const bool init) const
-{
-    if (init)
-    {
-        preset.chains[0].capture[0] = JACK_CAPTURE_PORT_1;
-        preset.chains[0].capture[1] = JACK_CAPTURE_PORT_2;
-        preset.chains[0].playback[0] = JACK_PLAYBACK_PORT_1;
-        preset.chains[0].playback[1] = JACK_PLAYBACK_PORT_2;
-    }
-    else
-    {
-        preset.chains[0].capture = _current.chains[0].capture;
-        preset.chains[0].playback = _current.chains[0].playback;
-    }
-
-    for (ChainRow& chain : preset.chains)
-    {
-        chain.blocks.resize(NUM_BLOCKS_PER_PRESET);
-
-        for (Block& block : chain.blocks)
-            allocBlock(block);
-    }
-}
-
-void HostConnector::resetPreset(Preset& preset) const
+void HostConnector::resetPreset(Preset& preset)
 {
     preset.uuid = generateUUID();
     preset.scene = 0;
@@ -7492,9 +7539,27 @@ void HostConnector::resetPreset(Preset& preset) const
 
     for (uint8_t s = 0; s < NUM_SCENES_PER_PRESET; ++s)
         preset.sceneNames[s].clear();
+
+    resetPresetPorts(preset);
 }
 
-void HostConnector::setEnableChangesNotSavedToPreset(Block& blockdata, const bool changesNotSavedToPreset) const
+void HostConnector::resetPresetPorts(Preset& preset, const bool usingDefault)
+{
+    if (usingDefault)
+    {
+        preset.chains[0].capture[0] = JACK_CAPTURE_PORT_1;
+        preset.chains[0].capture[1] = JACK_CAPTURE_PORT_2;
+        preset.chains[0].playback[0] = JACK_PLAYBACK_PORT_1;
+        preset.chains[0].playback[1] = JACK_PLAYBACK_PORT_2;
+    }
+    else
+    {
+        preset.chains[0].capture = _current.chains[0].capture;
+        preset.chains[0].playback = _current.chains[0].playback;
+    }
+}
+
+void HostConnector::setEnableChangesNotSavedToPreset(Block& blockdata, const bool changesNotSavedToPreset)
 {
     if (!changesNotSavedToPreset)
     {
@@ -7517,7 +7582,9 @@ void HostConnector::setEnableChangesNotSavedToPreset(Block& blockdata, const boo
     }
 }
 
-void HostConnector::setParamChangesNotSavedToPreset(Block& blockdata, const uint8_t paramIndex, const bool changesNotSavedToPreset) const
+void HostConnector::setParamChangesNotSavedToPreset(Block& blockdata,
+                                                    const uint8_t paramIndex,
+                                                    const bool changesNotSavedToPreset)
 {
     Parameter& paramdata(blockdata.parameters[paramIndex]);
 

--- a/src/connector.cpp
+++ b/src/connector.cpp
@@ -1554,39 +1554,125 @@ bool HostConnector::reorderBlock(const uint8_t row, const uint8_t orig, const ui
         hostEnsureStereoChain(_current.preset, row, blockStart);
 
     // update bindings
-    const auto updateBinding = [=](auto& bindingdata) {
-        if (bindingdata.row != row)
-            return;
-        if (bindingdata.block < left || bindingdata.block > right)
-            return;
-
-        // block matches orig, moving it to dest
-        if (bindingdata.block == orig)
-            bindingdata.block = dest;
-
-        // block matches dest, moving it by +1 or -1 accordingly
-        else if (bindingdata.block == dest)
-            bindingdata.block += orig > dest ? 1 : -1;
-
-        // block > dest, moving +1
-        else if (bindingdata.block > dest)
-            ++bindingdata.block;
-
-        // block < dest, moving -1
-        else
-            --bindingdata.block;
-
-        assert(bindingdata.block < NUM_BLOCKS_PER_PRESET);
-        assert(bindingdata.block < NUM_BLOCKS_PER_PRESET);
-    };
-
     for (uint8_t hwid = 0; hwid < NUM_BINDING_ACTUATORS; ++hwid)
     {
-        for (ParameterBinding& bindingdata : _current.bindings[hwid].parameters)
-            updateBinding(bindingdata);
+        if (std::list<ParameterBinding>& bindings(_current.bindings[hwid].parameters); ! bindings.empty())
+        {
+            for (ParameterBindingIterator it = bindings.begin(), end = bindings.end(); it != end; ++it)
+            {
+                if (it->row != row)
+                    continue;
+                if (it->block < left || it->block > right)
+                    continue;
 
-        for (PropertyBinding& bindingdata : _current.bindings[hwid].properties)
-            updateBinding(bindingdata);
+                uint8_t block = it->block;
+                const Block& blockdata = chain.blocks[block];
+
+                // block matches orig, moving it to dest
+                if (block == orig)
+                    block = dest;
+
+                // block matches dest, moving it by +1 or -1 accordingly
+                else if (block == dest)
+                    block += orig > dest ? 1 : -1;
+
+                // block > dest, moving +1
+                else if (block > dest)
+                    ++block;
+
+                // block < dest, moving -1
+                else
+                    --block;
+
+                assert(block < NUM_BLOCKS_PER_PRESET);
+
+                const float min = it->min;
+                const float max = it->max;
+
+                if (it->meta.isBypass)
+                {
+                    it = bindings.erase(it);
+                    bindings.insert(it, {
+                        .row = row,
+                        .block = block,
+                        .min = min,
+                        .max = max,
+                        .parameterSymbol = ":bypass",
+                        .meta = {
+                            .block = blockdata,
+                            .parameterIndex = 0,
+                            .isBypass = true,
+                        },
+                    });
+                }
+                else
+                {
+                    const uint8_t parameterIndex = it->meta.parameterIndex;
+                    const std::string parameterSymbol = it->parameterSymbol;
+
+                    it = bindings.erase(it);
+                    bindings.insert(it, {
+                        .row = row,
+                        .block = block,
+                        .min = min,
+                        .max = max,
+                        .parameterSymbol = parameterSymbol,
+                        .meta = {
+                            .block = blockdata,
+                            .parameterIndex = parameterIndex,
+                            .parameter = blockdata.parameters[parameterIndex],
+                        },
+                    });
+                }
+            }
+        }
+
+        if (std::list<PropertyBinding>& bindings(_current.bindings[hwid].properties); ! bindings.empty())
+        {
+            for (PropertyBindingIterator it = bindings.begin(), end = bindings.end(); it != end; ++it)
+            {
+                if (it->row != row)
+                    continue;
+                if (it->block < left || it->block > right)
+                    continue;
+
+                uint8_t block = it->block;
+                const Block& blockdata = chain.blocks[block];
+
+                // block matches orig, moving it to dest
+                if (block == orig)
+                    block = dest;
+
+                // block matches dest, moving it by +1 or -1 accordingly
+                else if (block == dest)
+                    block += orig > dest ? 1 : -1;
+
+                // block > dest, moving +1
+                else if (block > dest)
+                    ++block;
+
+                // block < dest, moving -1
+                else
+                    --block;
+
+                assert(block < NUM_BLOCKS_PER_PRESET);
+
+                const uint8_t propertyIndex = it->meta.propertyIndex;
+                const std::string propertyURI = it->propertyURI;
+
+                it = bindings.erase(it);
+                bindings.insert(it, {
+                    .row = row,
+                    .block = block,
+                    .propertyURI = propertyURI,
+                    .meta = {
+                        .propertyIndex = propertyIndex,
+                        .block = blockdata,
+                        .property = blockdata.properties[propertyIndex],
+                    },
+                });
+            }
+        }
     }
 
     _current.dirty = true;

--- a/src/connector.hpp
+++ b/src/connector.hpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024-2025 Filipe Coelho <falktx@darkglass.com>
+// SPDX-FileCopyrightText: 2024-2026 Filipe Coelho <falktx@darkglass.com>
 // SPDX-License-Identifier: ISC
 
 #pragma once
@@ -13,6 +13,23 @@
 #include <array>
 #include <list>
 #include <unordered_map>
+
+// --------------------------------------------------------------------------------------------------------------------
+
+// handy macro for allowing move operators but not copy
+// this ensures we don't copy too much data around, which would be expensive on the CPU
+// we make an exception for assignment, which would otherwise make the code too verbose
+#define CLASS_ONLY_MOVE_NO_COPY(CLASS)         \
+    CLASS(CLASS&&) = default;                  \
+    CLASS &operator=(CLASS&&) = default;       \
+    CLASS(const CLASS&) = delete;              \
+    CLASS &operator=(const CLASS&) = default;
+
+// extend the above to also allow empty constructor
+#define CLASS_ONLY_MOVE_INIT_NO_COPY(CLASS) \
+    public:                                 \
+    CLASS() = default;                      \
+    CLASS_ONLY_MOVE_NO_COPY(CLASS)
 
 enum ExtraLv2Flags {
     Lv2ParameterVirtual = 1 << 12,
@@ -126,7 +143,7 @@ struct HostConnector : Host::FeedbackCallback {
     struct Parameter {
         std::string symbol;
         float value;
-        struct {
+        struct Meta {
             // convenience meta-data, not stored in json state
             uint32_t flags;
             uint32_t designation;
@@ -139,13 +156,15 @@ struct HostConnector : Host::FeedbackCallback {
             std::string shortname;
             std::string unit;
             std::vector<Lv2ScalePoint> scalePoints;
+            CLASS_ONLY_MOVE_INIT_NO_COPY(Meta)
         } meta;
+        CLASS_ONLY_MOVE_INIT_NO_COPY(Parameter)
     };
 
     struct Property {
         std::string uri;
         std::string value; // TODO float or string
-        struct {
+        struct Meta {
             // convenience meta-data, not stored in json state
             uint32_t flags;
             uint8_t hwbinding;
@@ -154,7 +173,9 @@ struct HostConnector : Host::FeedbackCallback {
             std::string defpath; // used for Lv2PropertyIsPath
             std::string name;
             std::string shortname;
+            CLASS_ONLY_MOVE_INIT_NO_COPY(Meta)
         } meta;
+        CLASS_ONLY_MOVE_INIT_NO_COPY(Property)
     };
 
     enum SceneMode {
@@ -177,15 +198,16 @@ struct HostConnector : Host::FeedbackCallback {
 
     struct SceneValues {
         bool enabled;
-        std::vector<float> parameters;
-        std::vector<std::string> properties;
+        std::array<float, MAX_PARAMS_PER_BLOCK> parameters;
+        std::array<std::string, MAX_PARAMS_PER_BLOCK> properties;
+        CLASS_ONLY_MOVE_INIT_NO_COPY(SceneValues)
     };
 
     struct Block {
         bool enabled;
         std::string quickPotSymbol;
         std::string uri;
-        struct {
+        struct Meta {
             // convenience meta-data, not stored in json state
             // TODO remove details directly provided by plugin data
             struct {
@@ -206,9 +228,10 @@ struct HostConnector : Host::FeedbackCallback {
             std::string abbreviation;
             std::string brand;
             Lv2Category category;
+            CLASS_ONLY_MOVE_INIT_NO_COPY(Meta)
         } meta;
-        std::vector<Parameter> parameters;
-        std::vector<Property> properties;
+        std::array<Parameter, MAX_PARAMS_PER_BLOCK> parameters;
+        std::array<Property, MAX_PARAMS_PER_BLOCK> properties;
         std::array<SceneValues, NUM_SCENES_PER_PRESET> sceneValues;
 
         // keep hold of plugin data
@@ -238,6 +261,7 @@ struct HostConnector : Host::FeedbackCallback {
         std::array<SceneValues, NUM_SCENES_PER_PRESET> lastSavedSceneValues;
         std::unordered_map<std::string, uint8_t> parameterSymbolToIndexMap;
         std::unordered_map<std::string, uint8_t> propertyURIToIndexMap;
+        CLASS_ONLY_MOVE_INIT_NO_COPY(Block)
     };
 
     struct ParameterBinding {
@@ -245,20 +269,32 @@ struct HostConnector : Host::FeedbackCallback {
         uint8_t block;
         float min;
         float max;
-        std::string parameterSymbol;
-        struct {
-            // convenience meta-data, not stored in json state
-            uint8_t parameterIndex;
+        const std::string parameterSymbol;
+        // convenience data, not stored in json state
+        const struct Meta {
+            const Block &block;
+            const uint8_t parameterIndex;
+            union {
+                struct {
+                    bool isBypass;
+                };
+                struct {
+                    bool _padding;
+                    const Parameter &parameter;
+                };
+            };
         } meta;
     };
 
     struct PropertyBinding {
         uint8_t row;
         uint8_t block;
-        std::string propertyURI;
-        struct {
-            // convenience meta-data, not stored in json state
-            uint8_t propertyIndex;
+        const std::string propertyURI;
+        // convenience data, not stored in json state
+        const struct Meta {
+            const uint8_t propertyIndex;
+            const Block &block;
+            const Property &property;
         } meta;
     };
 
@@ -267,14 +303,19 @@ struct HostConnector : Host::FeedbackCallback {
         std::list<ParameterBinding> parameters;
         std::list<PropertyBinding> properties;
         double value; // NOTE normalized 0-1, updated automatically if single binding or using scenes
+    private:
+        friend struct HostConnector;
+        void copy(const Bindings&);
+        CLASS_ONLY_MOVE_INIT_NO_COPY(Bindings)
     };
 
     struct ChainRow {
-        std::vector<Block> blocks;
+        std::array<Block, NUM_BLOCKS_PER_PRESET> blocks;
         std::array<std::string, 2> capture;
         std::array<std::string, 2> playback;
         std::array<uint16_t, 2> captureId;
         std::array<uint16_t, 2> playbackId;
+        CLASS_ONLY_MOVE_INIT_NO_COPY(ChainRow)
     };
 
     struct Preset {
@@ -292,6 +333,8 @@ struct HostConnector : Host::FeedbackCallback {
         friend struct HostConnector;
         friend class WebSocketConnector;
         std::array<ChainRow, NUM_BLOCK_CHAIN_ROWS> chains;
+        void copy(const Preset&);
+        CLASS_ONLY_MOVE_INIT_NO_COPY(Preset)
     };
 
     struct Current : Preset {
@@ -883,13 +926,13 @@ private:
     void jsonPresetLoad(Preset& presetdata, const nlohmann::json& json) const;
 
     // saves preset data, also no host commands
-    void jsonPresetSave(const Preset& presetdata, nlohmann::json& json) const;
+    static void jsonPresetSave(const Preset& presetdata, nlohmann::json& json);
 
     // load preset data from the current bank, only does host commands
     void hostLoadPreset(uint8_t preset);
 
     // unload "old" and load current preset, only does host commands
-    void hostSwitchPreset(const Current& old);
+    void hostSwitchPreset(const Preset& prev, uint8_t prevPreset, uint8_t prevNumLoadedPlugins);
 
     // add (active==true) or preload block defined by blockdata to instance_number
     bool hostLoadInstance(const Block& blockdata, uint16_t instance_number, bool active);
@@ -922,14 +965,13 @@ private:
                    uint8_t numSideInputs,
                    uint8_t numSideOutputs) const;
 
-    void allocBlock(Block& blockdata) const;
-    void resetBlock(Block& blockdata) const;
+    static void resetBlock(Block& blockdata);
 
-    void allocPreset(Preset& preset, bool init = true) const;
-    void resetPreset(Preset& preset) const;
+    void resetPreset(Preset& preset);
+    void resetPresetPorts(Preset& preset, bool usingDefault = true);
 
-    void setEnableChangesNotSavedToPreset(Block& blockdata, bool changesNotSavedToPreset) const;
-    void setParamChangesNotSavedToPreset(Block& blockdata, uint8_t paramIndex, bool changesNotSavedToPreset) const;
+    static void setEnableChangesNotSavedToPreset(Block& blockdata, bool changesNotSavedToPreset);
+    static void setParamChangesNotSavedToPreset(Block& blockdata, uint8_t paramIndex, bool changesNotSavedToPreset);
 };
 
 using HostBindings = HostConnector::Bindings;
@@ -958,6 +1000,31 @@ static inline constexpr bool hasScenes(const HostProperty& prop)
 static inline constexpr bool hasScenes(const HostBlock& block)
 {
     return block.meta.enable.hasScenes;
+}
+
+static inline bool hasScenes(const HostBindings& bindings)
+{
+    for (const HostParameterBinding &binding : bindings.parameters)
+    {
+        if (binding.meta.isBypass)
+        {
+            if (hasScenes(binding.meta.block))
+                return true;
+        }
+        else
+        {
+            if (hasScenes(binding.meta.parameter))
+                return true;
+        }
+    }
+
+    for (const HostPropertyBinding &binding : bindings.properties)
+    {
+        if (hasScenes(binding.meta.property))
+            return true;
+    }
+
+    return false;
 }
 
 // --------------------------------------------------------------------------------------------------------------------

--- a/src/connector.hpp
+++ b/src/connector.hpp
@@ -31,6 +31,48 @@
     CLASS() = default;                      \
     CLASS_ONLY_MOVE_NO_COPY(CLASS)
 
+// handy class to pre-allocate an std::vector to a known size
+template<class T, int numElements>
+class heap_array : public std::vector<T>
+{
+public:
+    // allocate known number of elements by default
+    heap_array() : std::vector<T>(numElements) {}
+
+    // custom assignment operator, default method generates errors
+    heap_array& operator=(const heap_array& other)
+    {
+        assert(this->size() == numElements);
+        assert(this->size() == other.size());
+        for (int i = 0; i < numElements; ++i)
+            (*this)[i] = other[i];
+        return *this;
+    }
+
+    // use default methods for destructor and move operators
+    ~heap_array() = default;
+    heap_array(heap_array&&) = default;
+    heap_array& operator=(heap_array&&) = default;
+
+    // do not allow copy constructor
+    heap_array(const heap_array&) = delete;
+
+    // unwanted methods, trying to force fixed size
+    void append_range() = delete;
+    void clear() = delete;
+    void insert() = delete;
+    void emplace() = delete;
+    void emplace_back() = delete;
+    void erase() = delete;
+    void pop_back() = delete;
+    void push_back() = delete;
+    void reserve() = delete;
+    void resize() = delete;
+    void swap() = delete;
+};
+
+// --------------------------------------------------------------------------------------------------------------------
+
 enum ExtraLv2Flags {
     Lv2ParameterVirtual = 1 << 12,
     Lv2ParameterInScene = 1 << 13,
@@ -198,8 +240,8 @@ struct HostConnector : Host::FeedbackCallback {
 
     struct SceneValues {
         bool enabled;
-        std::array<float, MAX_PARAMS_PER_BLOCK> parameters;
-        std::array<std::string, MAX_PARAMS_PER_BLOCK> properties;
+        heap_array<float, MAX_PARAMS_PER_BLOCK> parameters;
+        heap_array<std::string, MAX_PARAMS_PER_BLOCK> properties;
         CLASS_ONLY_MOVE_INIT_NO_COPY(SceneValues)
     };
 
@@ -230,9 +272,9 @@ struct HostConnector : Host::FeedbackCallback {
             Lv2Category category;
             CLASS_ONLY_MOVE_INIT_NO_COPY(Meta)
         } meta;
-        std::array<Parameter, MAX_PARAMS_PER_BLOCK> parameters;
-        std::array<Property, MAX_PARAMS_PER_BLOCK> properties;
-        std::array<SceneValues, NUM_SCENES_PER_PRESET> sceneValues;
+        heap_array<Parameter, MAX_PARAMS_PER_BLOCK> parameters;
+        heap_array<Property, MAX_PARAMS_PER_BLOCK> properties;
+        heap_array<SceneValues, NUM_SCENES_PER_PRESET> sceneValues;
 
         // keep hold of plugin data
         std::shared_ptr<const Lv2Plugin> plugin;
@@ -258,7 +300,7 @@ struct HostConnector : Host::FeedbackCallback {
     private:
         // extra details, not stored in json state
         friend struct HostConnector;
-        std::array<SceneValues, NUM_SCENES_PER_PRESET> lastSavedSceneValues;
+        heap_array<SceneValues, NUM_SCENES_PER_PRESET> lastSavedSceneValues;
         std::unordered_map<std::string, uint8_t> parameterSymbolToIndexMap;
         std::unordered_map<std::string, uint8_t> propertyURIToIndexMap;
         CLASS_ONLY_MOVE_INIT_NO_COPY(Block)
@@ -312,7 +354,7 @@ struct HostConnector : Host::FeedbackCallback {
     };
 
     struct ChainRow {
-        std::array<Block, NUM_BLOCKS_PER_PRESET> blocks;
+        heap_array<Block, NUM_BLOCKS_PER_PRESET> blocks;
         std::array<std::string, 2> capture;
         std::array<std::string, 2> playback;
         std::array<uint16_t, 2> captureId;
@@ -324,17 +366,17 @@ struct HostConnector : Host::FeedbackCallback {
         uint8_t scene;
         std::string name;
         std::string filename;
-        std::array<Bindings, NUM_BINDING_ACTUATORS> bindings;
+        heap_array<Bindings, NUM_BINDING_ACTUATORS> bindings;
         struct {
             uint32_t color;
             std::string style;
         } background;
-        std::array<std::string, NUM_SCENES_PER_PRESET> sceneNames;
+        heap_array<std::string, NUM_SCENES_PER_PRESET> sceneNames;
         std::array<unsigned char, UUID_SIZE> uuid;
     private:
         friend struct HostConnector;
         friend class WebSocketConnector;
-        std::array<ChainRow, NUM_BLOCK_CHAIN_ROWS> chains;
+        heap_array<ChainRow, NUM_BLOCK_CHAIN_ROWS> chains;
         void copy(const Preset&);
         CLASS_ONLY_MOVE_INIT_NO_COPY(Preset)
     };
@@ -375,7 +417,7 @@ protected:
     Current _current;
 
     // default state for each preset
-    std::array<Preset, NUM_PRESETS_PER_BANK> _presets;
+    heap_array<Preset, NUM_PRESETS_PER_BANK> _presets;
 
     // current connector callback
     Callback* _callback = nullptr;

--- a/src/connector.hpp
+++ b/src/connector.hpp
@@ -279,7 +279,9 @@ struct HostConnector : Host::FeedbackCallback {
                     bool isBypass;
                 };
                 struct {
-                    bool _padding;
+                    // NOTE referencing `isBypassParameter` can generate a build error under GCC9
+                    // but not referencing it generates a warning on GCC>9
+                    bool isBypassParameter;
                     const Parameter &parameter;
                 };
             };


### PR DESCRIPTION
While preparing changes regarding scenes, I was hitting a wall with the way bindings are implemented, and noticed a couple of things that would be nice to change.
So here comes a backport of scene expansion, so its easier to review and test.

In short:
1. don't allow connector preset-related data to be copied, which can be expensive on the CPU - we do this with some macros as to not make code too verbose, bindings needed some tweaks as we then cannot copy std::list directly
2. once copies are not allowed, we can store references in the bindings data, which helps in finding the block and parameter related to a specific binding. a special case is added for bypass
3. convert use of std::vector + dedicate alloc calls into a _simple std::array_, just to simplify things (EDIT: std::array caused stack overflow due to too much data, I added a std::array-like class in the code using std::vector as base)
4. some methods were made static, as they dont use any class member variables
