### PR TITLE
Expose method to reload plugin license flags

### DIFF
--- a/src/lv2.cpp
+++ b/src/lv2.cpp
@@ -610,35 +610,13 @@ struct Lv2World::Impl
         if (path_contains(bundlepath, homedir()))
             retplugin->flags |= Lv2PluginIsUserRemovable;
 
-        if (lilv_plugin_has_extension_data(plugin, ns.modlicense_interface))
-        {
-            retplugin->flags |= Lv2PluginIsCommercial;
-
-            static const std::string keysdir = _keysdir();
-
-            std::string licensefile;
-           #ifdef _DARKGLASS_DEVICE_PABLITO
-            // system plugins in Anagram all share the same license URI
-            // if bundle is not user removable, assume to be a system plugin
-            if ((retplugin->flags & Lv2PluginIsUserRemovable) == 0)
-            {
-                licensefile = keysdir + "149e897c16e874bea75961557c8fef52567ad3db";
-            }
-            else
-           #endif
-            {
-                licensefile = keysdir + _sha1(uri);
-            }
-
-            if (std::filesystem::exists(licensefile))
-                retplugin->flags |= Lv2PluginIsLicensed;
-        }
-
         if (lilv_world_ask(world, urinode, ns.dgcs_blockImage, nullptr))
             retplugin->flags |= Lv2PluginHasBlockImageStyling;
 
         if (lilv_world_ask(world, urinode, ns.dgcs_blockSettings, nullptr))
             retplugin->flags |= Lv2PluginHasBlockSettingsStyling;
+
+        updatePluginLicenseFlags(uri, plugin, retplugin);
 
         // ------------------------------------------------------------------------------------------------------------
         // name
@@ -1901,6 +1879,36 @@ struct Lv2World::Impl
         return true;
     }
 
+    void reloadLicenses()
+    {
+        const LilvPlugin* plugin;
+
+        const pthread_mutex_guard pmg(bgLoadingMutex);
+
+        for (auto& it : pluginsCache)
+        {
+            const char* const uri = it.first.c_str();
+            PluginCache& cache = it.second;
+
+            if (cache.plugin == nullptr)
+                continue;
+
+            if (LilvNode* const urinode = lilv_new_uri(world, uri))
+            {
+                plugin = lilv_plugins_get_by_uri(plugins, urinode);
+                lilv_node_free(urinode);
+            }
+            else
+            {
+                continue;
+            }
+
+            // NOTE the cached plugin is typically const, and we want it that way
+            // reload of license information is the exception
+            updatePluginLicenseFlags(uri, plugin, const_cast<Lv2Plugin*>(cache.plugin.get()));
+        }
+    }
+
     static bool getPluginsInBundle(const char* const path, std::vector<std::string>& pluginsInBundle)
     {
         assert(path != nullptr && *path != '\0');
@@ -1976,6 +1984,38 @@ private:
 
             if (done)
                 break;
+        }
+    }
+
+    // NOTE Lv2PluginIsUserRemovable must have already been set, if relevant
+    void updatePluginLicenseFlags(const char* const uri,
+                                  const LilvPlugin* const lilvplugin,
+                                  Lv2Plugin* const plugin) const
+    {
+        if (lilv_plugin_has_extension_data(lilvplugin, ns.modlicense_interface))
+        {
+            plugin->flags |= Lv2PluginIsCommercial;
+
+            static const std::string keysdir = _keysdir();
+
+            std::string licensefile;
+           #ifdef _DARKGLASS_DEVICE_PABLITO
+            // system plugins in Anagram all share the same license URI
+            // if bundle is not user removable, assume to be a system plugin
+            if ((plugin->flags & Lv2PluginIsUserRemovable) == 0)
+            {
+                licensefile = keysdir + "149e897c16e874bea75961557c8fef52567ad3db";
+            }
+            else
+           #endif
+            {
+                licensefile = keysdir + _sha1(uri);
+            }
+
+            if (std::filesystem::exists(licensefile))
+                plugin->flags |= Lv2PluginIsLicensed;
+            else
+                plugin->flags &= ~Lv2PluginIsLicensed;
         }
     }
 
@@ -2158,6 +2198,11 @@ bool Lv2World::bundleAdd(const char* const path, std::vector<std::string>* plugi
 bool Lv2World::bundleRemove(const char* const path, std::vector<std::string>* pluginsInBundle)
 {
     return impl->bundleRemove(path, pluginsInBundle);
+}
+
+void Lv2World::reloadLicenses() const
+{
+    return impl->reloadLicenses();
 }
 
 bool Lv2World::getPluginsInBundle(const char* const path, std::vector<std::string>& pluginsInBundle)

--- a/src/lv2.hpp
+++ b/src/lv2.hpp
@@ -203,6 +203,12 @@ struct Lv2World {
     [[nodiscard]] bool bundleRemove(const char* path, std::vector<std::string>* pluginsInBundle = nullptr);
 
    /**
+    * reload licensed state of all cached plugins.
+    * @see Lv2PluginIsLicensed
+    */
+    void reloadLicenses() const;
+
+   /**
     * get the plugin URIs present in an LV2 bundle
     * @note path MUST end with OS-specific path separator (e.g. '/' under Linux)
     */


### PR DESCRIPTION
An exception for static plugin data after scanning that can change at runtime.
Plugin needs to be reloaded for the change to take place, but that can be managed elsewhere.
