### PR TITLE
Minor rework for expanded scenes

### DIFF
--- a/src/connector.cpp
+++ b/src/connector.cpp
@@ -1003,14 +1003,14 @@ bool HostConnector::saveCurrentPresetToFile(const char* const filename)
                 {
                     for (uint8_t s = 0; s < NUM_SCENES_PER_PRESET; ++s)
                     {
-                        blockdata.sceneValues[s].enabled = blockdata.enabled;
-                        blockdata.lastSavedSceneValues[s].enabled = blockdata.enabled;
+                        blockdata.scenes.enableValues[s] = blockdata.enabled;
+                        blockdata.scenes.lastSavedEnableValues[s] = blockdata.enabled;
                     }
                 }
                 else
                 {
-                    blockdata.sceneValues[scene].enabled = blockdata.enabled;
-                    blockdata.lastSavedSceneValues[scene].enabled = blockdata.enabled;
+                    blockdata.scenes.enableValues[scene] = blockdata.enabled;
+                    blockdata.scenes.lastSavedEnableValues[scene] = blockdata.enabled;
                 }
                 blockdata.meta.enable.tempSceneState = kTemporarySceneNone;
 
@@ -1025,14 +1025,14 @@ bool HostConnector::saveCurrentPresetToFile(const char* const filename)
                     {
                         for (uint8_t s = 0; s < NUM_SCENES_PER_PRESET; ++s)
                         {
-                            blockdata.sceneValues[s].parameters[p] = paramdata.value;
-                            blockdata.lastSavedSceneValues[s].parameters[p] = paramdata.value;
+                            paramdata.scenes.values[s] = paramdata.value;
+                            paramdata.scenes.lastSavedValues[s] = paramdata.value;
                         }
                     }
                     else
                     {
-                        blockdata.sceneValues[scene].parameters[p] = paramdata.value;
-                        blockdata.lastSavedSceneValues[scene].parameters[p] = paramdata.value;
+                        paramdata.scenes.values[scene] = paramdata.value;
+                        paramdata.scenes.lastSavedValues[scene] = paramdata.value;
                     }
                     paramdata.meta.tempSceneState = kTemporarySceneNone;
                 }
@@ -1288,13 +1288,13 @@ bool HostConnector::enableBlock(const uint8_t row, const uint8_t block, const bo
                 {
                     if (_current.scene == scene)
                         continue;
-                    blockdata.sceneValues[scene].enabled = blockdata.enabled;
-                    blockdata.lastSavedSceneValues[scene].enabled = blockdata.enabled;
+                    blockdata.scenes.enableValues[scene] = blockdata.enabled;
+                    blockdata.scenes.lastSavedEnableValues[scene] = blockdata.enabled;
                 }
             }
             // set new value for current scene
-            blockdata.sceneValues[_current.scene].enabled = enable;
-            blockdata.lastSavedSceneValues[_current.scene].enabled = enable;
+            blockdata.scenes.enableValues[_current.scene] = enable;
+            blockdata.scenes.lastSavedEnableValues[_current.scene] = enable;
             break;
 
         case SceneModeActivateTemporarily:
@@ -1308,7 +1308,7 @@ bool HostConnector::enableBlock(const uint8_t row, const uint8_t block, const bo
                 {
                     if (_current.scene == scene)
                         continue;
-                    blockdata.sceneValues[scene].enabled = blockdata.enabled;
+                    blockdata.scenes.enableValues[scene] = blockdata.enabled;
                 }
 
                 assert(blockdata.meta.enable.tempSceneState != kTemporarySceneActivate);
@@ -1317,7 +1317,7 @@ bool HostConnector::enableBlock(const uint8_t row, const uint8_t block, const bo
                                                     : kTemporarySceneNone;
             }
             // set new value for current scene
-            blockdata.sceneValues[_current.scene].enabled = enable;
+            blockdata.scenes.enableValues[_current.scene] = enable;
             break;
 
         case SceneModeClear:
@@ -1328,8 +1328,8 @@ bool HostConnector::enableBlock(const uint8_t row, const uint8_t block, const bo
             }
             for (uint8_t s = 0; s < NUM_SCENES_PER_PRESET; ++s)
             {
-                blockdata.sceneValues[s].enabled = enable;
-                blockdata.lastSavedSceneValues[s].enabled = enable;
+                blockdata.scenes.enableValues[s] = enable;
+                blockdata.scenes.lastSavedEnableValues[s] = enable;
             }
             break;
 
@@ -1345,7 +1345,7 @@ bool HostConnector::enableBlock(const uint8_t row, const uint8_t block, const bo
                                                     : kTemporarySceneNone;
             }
             for (uint8_t s = 0; s < NUM_SCENES_PER_PRESET; ++s)
-                blockdata.sceneValues[s].enabled = enable;
+                blockdata.scenes.enableValues[s] = enable;
             break;
 
         case SceneModeUpdate:
@@ -1353,14 +1353,14 @@ bool HostConnector::enableBlock(const uint8_t row, const uint8_t block, const bo
             {
                 for (uint8_t s = 0; s < NUM_SCENES_PER_PRESET; ++s)
                 {
-                    blockdata.sceneValues[s].enabled = enable;
-                    blockdata.lastSavedSceneValues[s].enabled = enable;
+                    blockdata.scenes.enableValues[s] = enable;
+                    blockdata.scenes.lastSavedEnableValues[s] = enable;
                 }
             }
             else
             {
-                blockdata.sceneValues[_current.scene].enabled = enable;
-                blockdata.lastSavedSceneValues[_current.scene].enabled = enable;
+                blockdata.scenes.enableValues[_current.scene] = enable;
+                blockdata.scenes.lastSavedEnableValues[_current.scene] = enable;
             }
             break;
 
@@ -1368,11 +1368,11 @@ bool HostConnector::enableBlock(const uint8_t row, const uint8_t block, const bo
             if (! blockdata.meta.enable.hasScenes)
             {
                 for (uint8_t s = 0; s < NUM_SCENES_PER_PRESET; ++s)
-                    blockdata.sceneValues[s].enabled = enable;
+                    blockdata.scenes.enableValues[s] = enable;
             }
             else
             {
-                blockdata.sceneValues[_current.scene].enabled = enable;
+                blockdata.scenes.enableValues[_current.scene] = enable;
             }
             break;
         }
@@ -1615,8 +1615,8 @@ bool HostConnector::replaceBlock(const uint8_t row,
 
             for (uint8_t s = 0; s < NUM_SCENES_PER_PRESET; ++s)
             {
-                blockdata.sceneValues[s].enabled = true;
-                blockdata.lastSavedSceneValues[s].enabled = true;
+                blockdata.scenes.enableValues[s] = true;
+                blockdata.scenes.lastSavedEnableValues[s] = true;
             }
 
             for (uint8_t p = 0; p < MAX_PARAMS_PER_BLOCK; ++p)
@@ -1640,8 +1640,8 @@ bool HostConnector::replaceBlock(const uint8_t row,
 
                 for (uint8_t s = 0; s < NUM_SCENES_PER_PRESET; ++s)
                 {
-                    blockdata.sceneValues[s].parameters[p] = paramdata.value;
-                    blockdata.lastSavedSceneValues[s].parameters[p] = paramdata.value;
+                    paramdata.scenes.values[s] = paramdata.value;
+                    paramdata.scenes.lastSavedValues[s] = paramdata.value;
                 }
             }
 
@@ -2026,8 +2026,8 @@ bool HostConnector::resetBlock(const uint8_t row, const uint8_t block, const boo
 
     for (uint8_t s = 0; s < NUM_SCENES_PER_PRESET; ++s)
     {
-        blockdata.sceneValues[s].enabled = blockdata.enabled;
-        blockdata.lastSavedSceneValues[s].enabled = blockdata.enabled;
+        blockdata.scenes.enableValues[s] = blockdata.enabled;
+        blockdata.scenes.lastSavedEnableValues[s] = blockdata.enabled;
     }
 
     if (resetUserDefaults)
@@ -2094,8 +2094,8 @@ bool HostConnector::resetBlock(const uint8_t row, const uint8_t block, const boo
 
         for (uint8_t s = 0; s < NUM_SCENES_PER_PRESET; ++s)
         {
-            blockdata.sceneValues[s].parameters[p] = paramdata.value;
-            blockdata.lastSavedSceneValues[s].parameters[p] = paramdata.value;
+            paramdata.scenes.values[s] = paramdata.value;
+            paramdata.scenes.lastSavedValues[s] = paramdata.value;
         }
     }
 
@@ -2359,6 +2359,14 @@ void HostConnector::renamePreset(const uint8_t preset, const char* const name)
 
 // --------------------------------------------------------------------------------------------------------------------
 
+// std::vector<bool> cannot swap values directly, give it a little hand...
+static void vector_bool_swap(std::vector<bool>& vector, uint8_t a, uint8_t b)
+{
+    const bool tmp = vector[b];
+    vector[b] = vector[a];
+    vector[a] = tmp;
+}
+
 bool HostConnector::reorderScenes(const uint8_t orig, const uint8_t dest)
 {
     mod_log_debug("reorderScenes(%u, %u)", orig, dest);
@@ -2383,8 +2391,8 @@ bool HostConnector::reorderScenes(const uint8_t orig, const uint8_t dest)
                 if (blockdata.meta.numParametersInScenes == 0)
                     continue;
 
-                std::swap(blockdata.sceneValues[sceneA], blockdata.sceneValues[sceneB]);
-                std::swap(blockdata.lastSavedSceneValues[sceneA], blockdata.lastSavedSceneValues[sceneB]);
+                vector_bool_swap(blockdata.scenes.enableValues, sceneA, sceneB);
+                vector_bool_swap(blockdata.scenes.lastSavedEnableValues, sceneA, sceneB);
             }
         }
 
@@ -2461,8 +2469,8 @@ void HostConnector::swapScenes(const uint8_t sceneA, const uint8_t sceneB)
             if (blockdata.meta.numParametersInScenes == 0)
                 continue;
 
-            std::swap(blockdata.sceneValues[sceneA], blockdata.sceneValues[sceneB]);
-            std::swap(blockdata.lastSavedSceneValues[sceneA], blockdata.lastSavedSceneValues[sceneB]);
+            vector_bool_swap(blockdata.scenes.enableValues, sceneA, sceneB);
+            vector_bool_swap(blockdata.scenes.lastSavedEnableValues, sceneA, sceneB);
         }
     }
 
@@ -2530,10 +2538,7 @@ bool HostConnector::switchScene(const uint8_t scene)
 
             params.clear();
 
-            const SceneValues& sceneValues(blockdata.lastSavedSceneValues[scene]);
-
-            SceneValues& previousSceneValues(blockdata.sceneValues[previousScene]);
-            const SceneValues& previousSavedSceneValues(blockdata.lastSavedSceneValues[previousScene]);
+            const bool blockEnabled = blockdata.scenes.lastSavedEnableValues[scene];
 
             // revert temp scene state
             switch (blockdata.meta.enable.tempSceneState)
@@ -2545,19 +2550,19 @@ bool HostConnector::switchScene(const uint8_t scene)
                 --blockdata.meta.numParametersInScenes;
                 blockdata.meta.enable.hasScenes = false;
                 blockdata.meta.enable.tempSceneState = kTemporarySceneNone;
-                previousSceneValues.enabled = previousSavedSceneValues.enabled;
+                blockdata.scenes.enableValues[previousScene] = blockdata.scenes.lastSavedEnableValues[previousScene];
                 break;
             case kTemporarySceneClear:
                 assert(!blockdata.meta.enable.hasScenes);
                 ++blockdata.meta.numParametersInScenes;
                 blockdata.meta.enable.hasScenes = true;
                 blockdata.meta.enable.tempSceneState = kTemporarySceneNone;
-                previousSceneValues.enabled = previousSavedSceneValues.enabled;
+                blockdata.scenes.enableValues[previousScene] = blockdata.scenes.lastSavedEnableValues[previousScene];
                 break;
             }
 
             // bypass/disable first if relevant
-            if (blockdata.enabled != sceneValues.enabled && !sceneValues.enabled)
+            if (blockdata.enabled != blockEnabled && !blockEnabled)
             {
                 blockdata.enabled = false;
                 hostBypassBlockPair(hbp, true);
@@ -2581,20 +2586,20 @@ bool HostConnector::switchScene(const uint8_t scene)
                     --blockdata.meta.numParametersInScenes;
                     paramdata.meta.flags &= ~Lv2ParameterInScene;
                     paramdata.meta.tempSceneState = kTemporarySceneNone;
-                    previousSceneValues.parameters[p] = previousSavedSceneValues.parameters[p];
+                    paramdata.scenes.values[previousScene] = paramdata.scenes.lastSavedValues[previousScene];
                     break;
                 case kTemporarySceneClear:
                     assert((paramdata.meta.flags & Lv2ParameterInScene) == 0);
                     ++blockdata.meta.numParametersInScenes;
                     paramdata.meta.flags |= Lv2ParameterInScene;
                     paramdata.meta.tempSceneState = kTemporarySceneNone;
-                    previousSceneValues.parameters[p] = previousSavedSceneValues.parameters[p];
+                    paramdata.scenes.values[previousScene] = paramdata.scenes.lastSavedValues[previousScene];
                     break;
                 }
 
-                if (isNotEqual(paramdata.value, sceneValues.parameters[p]))
+                if (isNotEqual(paramdata.value, paramdata.scenes.lastSavedValues[scene]))
                 {
-                    paramdata.value = sceneValues.parameters[p];
+                    paramdata.value = paramdata.scenes.lastSavedValues[scene];
                     params.push_back({ paramdata.symbol.c_str(), paramdata.value });
                 }
             }
@@ -2602,7 +2607,7 @@ bool HostConnector::switchScene(const uint8_t scene)
             hostParamsFlushBlockPair(hbp, LV2_KXSTUDIO_PROPERTIES_RESET_NONE, params);
 
             // unbypass/enable last if relevant
-            if (blockdata.enabled != sceneValues.enabled && sceneValues.enabled)
+            if (blockdata.enabled != blockEnabled && blockEnabled)
             {
                 blockdata.enabled = true;
                 hostBypassBlockPair(hbp, false);
@@ -3425,13 +3430,13 @@ void HostConnector::setBlockParameter(const uint8_t row,
                 {
                     if (_current.scene == scene)
                         continue;
-                    blockdata.sceneValues[scene].parameters[paramIndex] = paramdata.value;
-                    blockdata.lastSavedSceneValues[scene].parameters[paramIndex] = paramdata.value;
+                    paramdata.scenes.values[scene] = paramdata.value;
+                    paramdata.scenes.lastSavedValues[scene] = paramdata.value;
                 }
             }
             // set new value for current scene
-            blockdata.sceneValues[_current.scene].parameters[paramIndex] = value;
-            blockdata.lastSavedSceneValues[_current.scene].parameters[paramIndex] = value;
+            paramdata.scenes.values[_current.scene] = value;
+            paramdata.scenes.lastSavedValues[_current.scene] = value;
             break;
 
         case SceneModeActivateTemporarily:
@@ -3445,7 +3450,7 @@ void HostConnector::setBlockParameter(const uint8_t row,
                 {
                     if (_current.scene == scene)
                         continue;
-                    blockdata.sceneValues[scene].parameters[paramIndex] = paramdata.value;
+                    paramdata.scenes.values[scene] = paramdata.value;
                 }
 
                 assert(paramdata.meta.tempSceneState != kTemporarySceneActivate);
@@ -3454,7 +3459,7 @@ void HostConnector::setBlockParameter(const uint8_t row,
                                               : kTemporarySceneNone;
             }
             // set new value for current scene
-            blockdata.sceneValues[_current.scene].parameters[paramIndex] = value;
+            paramdata.scenes.values[_current.scene] = value;
             break;
 
         case SceneModeClear:
@@ -3465,8 +3470,8 @@ void HostConnector::setBlockParameter(const uint8_t row,
             }
             for (uint8_t s = 0; s < NUM_SCENES_PER_PRESET; ++s)
             {
-                blockdata.sceneValues[s].parameters[paramIndex] = value;
-                blockdata.lastSavedSceneValues[s].parameters[paramIndex] = value;
+                paramdata.scenes.values[s] = value;
+                paramdata.scenes.lastSavedValues[s] = value;
             }
             break;
 
@@ -3482,7 +3487,7 @@ void HostConnector::setBlockParameter(const uint8_t row,
                                               : kTemporarySceneNone;
             }
             for (uint8_t s = 0; s < NUM_SCENES_PER_PRESET; ++s)
-                blockdata.sceneValues[s].parameters[paramIndex] = value;
+                paramdata.scenes.values[s] = value;
             break;
 
         case SceneModeUpdate:
@@ -3490,14 +3495,14 @@ void HostConnector::setBlockParameter(const uint8_t row,
             {
                 for (uint8_t s = 0; s < NUM_SCENES_PER_PRESET; ++s)
                 {
-                    blockdata.sceneValues[s].parameters[paramIndex] = value;
-                    blockdata.lastSavedSceneValues[s].parameters[paramIndex] = value;
+                    paramdata.scenes.values[s] = value;
+                    paramdata.scenes.lastSavedValues[s] = value;
                 }
             }
             else
             {
-                blockdata.sceneValues[_current.scene].parameters[paramIndex] = value;
-                blockdata.lastSavedSceneValues[_current.scene].parameters[paramIndex] = value;
+                paramdata.scenes.values[_current.scene] = value;
+                paramdata.scenes.lastSavedValues[_current.scene] = value;
             }
             break;
 
@@ -3505,11 +3510,11 @@ void HostConnector::setBlockParameter(const uint8_t row,
             if ((paramdata.meta.flags & Lv2ParameterInScene) == 0)
             {
                 for (uint8_t s = 0; s < NUM_SCENES_PER_PRESET; ++s)
-                    blockdata.sceneValues[s].parameters[paramIndex] = value;
+                    paramdata.scenes.values[s] = value;
             }
             else
             {
-                blockdata.sceneValues[_current.scene].parameters[paramIndex] = value;
+                paramdata.scenes.values[_current.scene] = value;
             }
             break;
         }
@@ -4926,7 +4931,7 @@ void HostConnector::jsonPresetLoad(Preset& presetdata, const nlohmann::json& jpr
                     blockdata.enabled = enabled;
 
                     for (uint8_t s = 0; s < NUM_SCENES_PER_PRESET; ++s)
-                        blockdata.sceneValues[s].enabled = enabled;
+                        blockdata.scenes.enableValues[s] = enabled;
                 }
 
                 // ----------------------------------------------------------------------------------------------------
@@ -4994,7 +4999,7 @@ void HostConnector::jsonPresetLoad(Preset& presetdata, const nlohmann::json& jpr
                                                                     jparam["value"].get<double>()));
 
                         for (uint8_t s = 0; s < NUM_SCENES_PER_PRESET; ++s)
-                            blockdata.sceneValues[s].parameters[paramIndex] = paramdata.value;
+                            paramdata.scenes.values[s] = paramdata.value;
                     }
                 }
 
@@ -5074,7 +5079,7 @@ void HostConnector::jsonPresetLoad(Preset& presetdata, const nlohmann::json& jpr
                                     ++blockdata.meta.numParametersInScenes;
                                 }
 
-                                blockdata.sceneValues[s].enabled = enabled;
+                                blockdata.scenes.enableValues[s] = enabled;
                             }
                         }
 
@@ -5136,7 +5141,7 @@ void HostConnector::jsonPresetLoad(Preset& presetdata, const nlohmann::json& jpr
                                         ++blockdata.meta.numParametersInScenes;
                                     }
 
-                                    blockdata.sceneValues[s].parameters[paramIndex] =
+                                    paramdata.scenes.values[s] =
                                         std::max(paramdata.meta.min, std::min<float>(paramdata.meta.max, value));
                                 }
                             }
@@ -5144,7 +5149,7 @@ void HostConnector::jsonPresetLoad(Preset& presetdata, const nlohmann::json& jpr
                     }
                 }
 
-                blockdata.lastSavedSceneValues = blockdata.sceneValues;
+                blockdata.scenes.lastSavedEnableValues = blockdata.scenes.enableValues;
             }
         }
     }
@@ -5682,7 +5687,7 @@ void HostConnector::jsonPresetSave(const Preset& presetdata, nlohmann::json& jpr
                         });
 
                         if (blockdata.meta.enable.hasScenes)
-                            jscene["enabled"] = blockdata.sceneValues[s].enabled;
+                            jscene["enabled"] = blockdata.scenes.enableValues[s];
 
                         {
                             auto& jsceneparams = jscene["parameters"];
@@ -5700,7 +5705,7 @@ void HostConnector::jsonPresetSave(const Preset& presetdata, nlohmann::json& jpr
 
                                 jsceneparams.push_back(nlohmann::json::object({
                                     { "symbol", paramdata.symbol },
-                                    { "value", blockdata.sceneValues[s].parameters[p] },
+                                    { "value", paramdata.scenes.values[s] },
                                 }));
                             }
                         }
@@ -6638,6 +6643,8 @@ void HostConnector::initBlock(HostConnector::Block& blockdata,
                 .unit = port.unit,
                 .scalePoints = port.scalePoints,
             },
+            .scenes = {
+            },
         };
     };
 
@@ -6708,11 +6715,12 @@ void HostConnector::initBlock(HostConnector::Block& blockdata,
 
     for (uint8_t p = numParams; p < MAX_PARAMS_PER_BLOCK; ++p)
     {
-        resetParameter(blockdata.parameters[p]);
+        Parameter& paramdata = blockdata.parameters[p];
+        resetParameter(paramdata);
         for (uint8_t s = 0; s < NUM_SCENES_PER_PRESET; ++s)
         {
-            blockdata.sceneValues[s].parameters[p] = 0.f;
-            blockdata.lastSavedSceneValues[s].parameters[p] = 0.f;
+            paramdata.scenes.values[s] = 0.f;
+            paramdata.scenes.lastSavedValues[s] = 0.f;
         }
     }
 
@@ -6721,8 +6729,8 @@ void HostConnector::initBlock(HostConnector::Block& blockdata,
 
     for (uint8_t s = 0; s < NUM_SCENES_PER_PRESET; ++s)
     {
-        blockdata.sceneValues[s].enabled = true;
-        blockdata.lastSavedSceneValues[s].enabled = true;
+        blockdata.scenes.enableValues[s] = true;
+        blockdata.scenes.lastSavedEnableValues[s] = true;
     }
 
     // override defaults from user
@@ -6794,12 +6802,13 @@ void HostConnector::initBlock(HostConnector::Block& blockdata,
         }
     }
 
-    for (uint8_t s = 0; s < NUM_SCENES_PER_PRESET; ++s)
+    for (uint8_t p = 0; p < numParams; ++p)
     {
-        for (uint8_t p = 0; p < numParams; ++p)
+        Parameter& paramdata = blockdata.parameters[p];
+        for (uint8_t s = 0; s < NUM_SCENES_PER_PRESET; ++s)
         {
-            blockdata.sceneValues[s].parameters[p] = blockdata.parameters[p].value;
-            blockdata.lastSavedSceneValues[s].parameters[p] = blockdata.parameters[p].value;
+            paramdata.scenes.values[s] = blockdata.parameters[p].value;
+            paramdata.scenes.lastSavedValues[s] = blockdata.parameters[p].value;
         }
     }
 }
@@ -6835,8 +6844,8 @@ void HostConnector::resetBlock(Block& blockdata)
 
     for (uint8_t s = 0; s < NUM_SCENES_PER_PRESET; ++s)
     {
-        blockdata.sceneValues[s].enabled = false;
-        blockdata.lastSavedSceneValues[s].enabled = false;
+        blockdata.scenes.enableValues[s] = false;
+        blockdata.scenes.lastSavedEnableValues[s] = false;
     }
 }
 
@@ -6912,8 +6921,8 @@ void HostConnector::setEnableChangesNotSavedToPreset(Block& blockdata, const boo
     }
     for (uint8_t s = 0; s < NUM_SCENES_PER_PRESET; ++s)
     {
-        blockdata.sceneValues[s].enabled = blockdata.enabled;
-        blockdata.lastSavedSceneValues[s].enabled = blockdata.enabled;
+        blockdata.scenes.enableValues[s] = blockdata.enabled;
+        blockdata.scenes.lastSavedEnableValues[s] = blockdata.enabled;
     }
 }
 
@@ -6939,8 +6948,8 @@ void HostConnector::setParamChangesNotSavedToPreset(Block& blockdata,
     }
     for (uint8_t s = 0; s < NUM_SCENES_PER_PRESET; ++s)
     {
-        blockdata.sceneValues[s].parameters[paramIndex] = paramdata.value;
-        blockdata.lastSavedSceneValues[s].parameters[paramIndex] = paramdata.value;
+        paramdata.scenes.values[s] = paramdata.value;
+        paramdata.scenes.lastSavedValues[s] = paramdata.value;
     }
 }
 

--- a/src/connector.cpp
+++ b/src/connector.cpp
@@ -1607,10 +1607,10 @@ bool HostConnector::replaceBlock(const uint8_t row,
 
             std::array<bool, MAX_PARAMS_PER_BLOCK> propsToReset{};
 
+            blockdata.meta.enable.changesNotSavedToPreset = false;
             blockdata.meta.enable.hasScenes = false;
             blockdata.meta.enable.hwbinding = UINT8_MAX;
             blockdata.meta.enable.tempSceneState = kTemporarySceneNone;
-            blockdata.meta.enable.changesNotSavedToPreset = false;
             blockdata.meta.numParametersInScenes = 0;
 
             for (uint8_t s = 0; s < NUM_SCENES_PER_PRESET; ++s)
@@ -2018,6 +2018,7 @@ bool HostConnector::resetBlock(const uint8_t row, const uint8_t block, const boo
 
     std::array<bool, MAX_PARAMS_PER_BLOCK> propsToReset{};
 
+    blockdata.meta.enable.changesNotSavedToPreset = false;
     blockdata.meta.enable.hasScenes = false;
     blockdata.meta.enable.hwbinding = UINT8_MAX;
     blockdata.meta.enable.tempSceneState = kTemporarySceneNone;
@@ -6577,10 +6578,10 @@ void HostConnector::initBlock(HostConnector::Block& blockdata,
     blockdata.quickPotSymbol.clear();
     blockdata.plugin = plugin;
 
+    blockdata.meta.enable.changesNotSavedToPreset = false;
     blockdata.meta.enable.hasScenes = false;
     blockdata.meta.enable.hwbinding = UINT8_MAX;
     blockdata.meta.enable.tempSceneState = kTemporarySceneNone;
-    blockdata.meta.enable.changesNotSavedToPreset = false;
     blockdata.meta.flags = plugin->flags;
     blockdata.meta.quickPotIndex = 0;
     blockdata.meta.numParametersInScenes = 0;
@@ -6811,10 +6812,10 @@ void HostConnector::resetBlock(Block& blockdata)
     blockdata.uri.clear();
     blockdata.quickPotSymbol.clear();
     blockdata.plugin.reset();
+    blockdata.meta.enable.changesNotSavedToPreset = false;
     blockdata.meta.enable.hasScenes = false;
     blockdata.meta.enable.hwbinding = UINT8_MAX;
     blockdata.meta.enable.tempSceneState = kTemporarySceneNone;
-    blockdata.meta.enable.changesNotSavedToPreset = false;
     blockdata.meta.flags = 0;
     blockdata.meta.quickPotIndex = 0;
     blockdata.meta.numParametersInScenes = 0;
@@ -6927,7 +6928,7 @@ void HostConnector::setParamChangesNotSavedToPreset(Block& blockdata,
         paramdata.meta.flags &= ~Lv2ParameterChangesNotSavedToPreset;
         return;
     }
-    
+
     paramdata.meta.flags |= Lv2ParameterChangesNotSavedToPreset;
 
     // clear Scenes

--- a/src/connector.cpp
+++ b/src/connector.cpp
@@ -231,6 +231,8 @@ static void resetParameter(HostConnector::Parameter& paramdata)
     paramdata = {};
     paramdata.meta.hwbinding = UINT8_MAX;
     paramdata.meta.max = 1.f;
+    paramdata.scenes.values.fill(0.f);
+    paramdata.scenes.lastSavedValues.fill(0.f);
 }
 
 static void resetProperty(HostConnector::Property& propdata)
@@ -1001,11 +1003,8 @@ bool HostConnector::saveCurrentPresetToFile(const char* const filename)
 
                 if (! blockdata.meta.enable.hasScenes)
                 {
-                    for (uint8_t s = 0; s < NUM_SCENES_PER_PRESET; ++s)
-                    {
-                        blockdata.scenes.enableValues[s] = blockdata.enabled;
-                        blockdata.scenes.lastSavedEnableValues[s] = blockdata.enabled;
-                    }
+                    blockdata.scenes.enableValues.fill(blockdata.enabled);
+                    blockdata.scenes.lastSavedEnableValues.fill(blockdata.enabled);
                 }
                 else
                 {
@@ -1023,11 +1022,8 @@ bool HostConnector::saveCurrentPresetToFile(const char* const filename)
                         continue;
                     if ((paramdata.meta.flags & Lv2ParameterInScene) == 0)
                     {
-                        for (uint8_t s = 0; s < NUM_SCENES_PER_PRESET; ++s)
-                        {
-                            paramdata.scenes.values[s] = paramdata.value;
-                            paramdata.scenes.lastSavedValues[s] = paramdata.value;
-                        }
+                        paramdata.scenes.values.fill(paramdata.value);
+                        paramdata.scenes.lastSavedValues.fill(paramdata.value);
                     }
                     else
                     {
@@ -1326,11 +1322,8 @@ bool HostConnector::enableBlock(const uint8_t row, const uint8_t block, const bo
                 --blockdata.meta.numParametersInScenes;
                 blockdata.meta.enable.hasScenes = false;
             }
-            for (uint8_t s = 0; s < NUM_SCENES_PER_PRESET; ++s)
-            {
-                blockdata.scenes.enableValues[s] = enable;
-                blockdata.scenes.lastSavedEnableValues[s] = enable;
-            }
+            blockdata.scenes.enableValues.fill(enable);
+            blockdata.scenes.lastSavedEnableValues.fill(enable);
             break;
 
         case SceneModeClearTemporarily:
@@ -1344,18 +1337,14 @@ bool HostConnector::enableBlock(const uint8_t row, const uint8_t block, const bo
                                                     ? kTemporarySceneClear
                                                     : kTemporarySceneNone;
             }
-            for (uint8_t s = 0; s < NUM_SCENES_PER_PRESET; ++s)
-                blockdata.scenes.enableValues[s] = enable;
+            blockdata.scenes.enableValues.fill(enable);
             break;
 
         case SceneModeUpdate:
             if (! blockdata.meta.enable.hasScenes)
             {
-                for (uint8_t s = 0; s < NUM_SCENES_PER_PRESET; ++s)
-                {
-                    blockdata.scenes.enableValues[s] = enable;
-                    blockdata.scenes.lastSavedEnableValues[s] = enable;
-                }
+                blockdata.scenes.enableValues.fill(enable);
+                blockdata.scenes.lastSavedEnableValues.fill(enable);
             }
             else
             {
@@ -1366,14 +1355,9 @@ bool HostConnector::enableBlock(const uint8_t row, const uint8_t block, const bo
 
         case SceneModeUpdateTemporarily:
             if (! blockdata.meta.enable.hasScenes)
-            {
-                for (uint8_t s = 0; s < NUM_SCENES_PER_PRESET; ++s)
-                    blockdata.scenes.enableValues[s] = enable;
-            }
+                blockdata.scenes.enableValues.fill(enable);
             else
-            {
                 blockdata.scenes.enableValues[_current.scene] = enable;
-            }
             break;
         }
     }
@@ -1613,15 +1597,11 @@ bool HostConnector::replaceBlock(const uint8_t row,
             blockdata.meta.enable.tempSceneState = kTemporarySceneNone;
             blockdata.meta.numParametersInScenes = 0;
 
-            for (uint8_t s = 0; s < NUM_SCENES_PER_PRESET; ++s)
-            {
-                blockdata.scenes.enableValues[s] = true;
-                blockdata.scenes.lastSavedEnableValues[s] = true;
-            }
+            blockdata.scenes.enableValues.fill(true);
+            blockdata.scenes.lastSavedEnableValues.fill(true);
 
-            for (uint8_t p = 0; p < MAX_PARAMS_PER_BLOCK; ++p)
+            for (Parameter& paramdata : blockdata.parameters)
             {
-                Parameter& paramdata(blockdata.parameters[p]);
                 if (isNullURI(paramdata.symbol))
                     break;
                 if ((paramdata.meta.flags & Lv2ParameterNotAllowedToChange) != 0)
@@ -1638,11 +1618,8 @@ bool HostConnector::replaceBlock(const uint8_t row,
                     params.push_back({ paramdata.symbol.c_str(), paramdata.meta.def });
                 }
 
-                for (uint8_t s = 0; s < NUM_SCENES_PER_PRESET; ++s)
-                {
-                    paramdata.scenes.values[s] = paramdata.value;
-                    paramdata.scenes.lastSavedValues[s] = paramdata.value;
-                }
+                paramdata.scenes.values.fill(paramdata.value);
+                paramdata.scenes.lastSavedValues.fill(paramdata.value);
             }
 
             _current.dirty = true;
@@ -2024,11 +2001,8 @@ bool HostConnector::resetBlock(const uint8_t row, const uint8_t block, const boo
     blockdata.meta.enable.tempSceneState = kTemporarySceneNone;
     blockdata.meta.numParametersInScenes = 0;
 
-    for (uint8_t s = 0; s < NUM_SCENES_PER_PRESET; ++s)
-    {
-        blockdata.scenes.enableValues[s] = blockdata.enabled;
-        blockdata.scenes.lastSavedEnableValues[s] = blockdata.enabled;
-    }
+    blockdata.scenes.enableValues.fill(blockdata.enabled);
+    blockdata.scenes.lastSavedEnableValues.fill(blockdata.enabled);
 
     if (resetUserDefaults)
     {
@@ -2092,11 +2066,8 @@ bool HostConnector::resetBlock(const uint8_t row, const uint8_t block, const boo
             params.push_back({ paramdata.symbol.c_str(), paramdata.meta.def });
         }
 
-        for (uint8_t s = 0; s < NUM_SCENES_PER_PRESET; ++s)
-        {
-            paramdata.scenes.values[s] = paramdata.value;
-            paramdata.scenes.lastSavedValues[s] = paramdata.value;
-        }
+        paramdata.scenes.values.fill(paramdata.value);
+        paramdata.scenes.lastSavedValues.fill(paramdata.value);
     }
 
     _current.dirty = true;
@@ -2903,9 +2874,8 @@ bool HostConnector::removeBindings(const uint8_t hwid)
                 blockdata.meta.enable.changesNotSavedToPreset = false;
             }
 
-            for (uint8_t p = 0; p < MAX_PARAMS_PER_BLOCK; ++p)
+            for (Parameter& paramdata : blockdata.parameters)
             {
-                Parameter& paramdata(blockdata.parameters[p]);
                 if (isNullURI(paramdata.symbol))
                     break;
 
@@ -3468,11 +3438,8 @@ void HostConnector::setBlockParameter(const uint8_t row,
                 --blockdata.meta.numParametersInScenes;
                 paramdata.meta.flags &= ~Lv2ParameterInScene;
             }
-            for (uint8_t s = 0; s < NUM_SCENES_PER_PRESET; ++s)
-            {
-                paramdata.scenes.values[s] = value;
-                paramdata.scenes.lastSavedValues[s] = value;
-            }
+            paramdata.scenes.values.fill(value);
+            paramdata.scenes.lastSavedValues.fill(value);
             break;
 
         case SceneModeClearTemporarily:
@@ -3486,18 +3453,14 @@ void HostConnector::setBlockParameter(const uint8_t row,
                                               ? kTemporarySceneClear
                                               : kTemporarySceneNone;
             }
-            for (uint8_t s = 0; s < NUM_SCENES_PER_PRESET; ++s)
-                paramdata.scenes.values[s] = value;
+            paramdata.scenes.values.fill(value);
             break;
 
         case SceneModeUpdate:
             if ((paramdata.meta.flags & Lv2ParameterInScene) == 0)
             {
-                for (uint8_t s = 0; s < NUM_SCENES_PER_PRESET; ++s)
-                {
-                    paramdata.scenes.values[s] = value;
-                    paramdata.scenes.lastSavedValues[s] = value;
-                }
+                paramdata.scenes.values.fill(value);
+                paramdata.scenes.lastSavedValues.fill(value);
             }
             else
             {
@@ -3508,14 +3471,9 @@ void HostConnector::setBlockParameter(const uint8_t row,
 
         case SceneModeUpdateTemporarily:
             if ((paramdata.meta.flags & Lv2ParameterInScene) == 0)
-            {
-                for (uint8_t s = 0; s < NUM_SCENES_PER_PRESET; ++s)
-                    paramdata.scenes.values[s] = value;
-            }
+                paramdata.scenes.values.fill(value);
             else
-            {
                 paramdata.scenes.values[_current.scene] = value;
-            }
             break;
         }
 
@@ -4728,12 +4686,10 @@ void HostConnector::hostRemoveAllBlockBindings(const uint8_t row, const uint8_t 
 
     blockdata.meta.enable.hwbinding = UINT8_MAX;
 
-    for (uint8_t p = 0; p < MAX_PARAMS_PER_BLOCK; ++p)
+    for (Parameter& paramdata : blockdata.parameters)
     {
-        Parameter& paramdata(blockdata.parameters[p]);
         if (isNullURI(paramdata.symbol))
             break;
-
         paramdata.meta.hwbinding = UINT8_MAX;
     }
 
@@ -4929,9 +4885,7 @@ void HostConnector::jsonPresetLoad(Preset& presetdata, const nlohmann::json& jpr
                     }
 
                     blockdata.enabled = enabled;
-
-                    for (uint8_t s = 0; s < NUM_SCENES_PER_PRESET; ++s)
-                        blockdata.scenes.enableValues[s] = enabled;
+                    blockdata.scenes.enableValues.fill(enabled);
                 }
 
                 // ----------------------------------------------------------------------------------------------------
@@ -4998,8 +4952,7 @@ void HostConnector::jsonPresetLoad(Preset& presetdata, const nlohmann::json& jpr
                                                     std::min<float>(paramdata.meta.max,
                                                                     jparam["value"].get<double>()));
 
-                        for (uint8_t s = 0; s < NUM_SCENES_PER_PRESET; ++s)
-                            paramdata.scenes.values[s] = paramdata.value;
+                        paramdata.scenes.values.fill(paramdata.value);
                     }
                 }
 
@@ -5150,6 +5103,13 @@ void HostConnector::jsonPresetLoad(Preset& presetdata, const nlohmann::json& jpr
                 }
 
                 blockdata.scenes.lastSavedEnableValues = blockdata.scenes.enableValues;
+
+                for (Parameter& paramdata : blockdata.parameters)
+                {
+                    if (isNullURI(paramdata.symbol))
+                        break;
+                    paramdata.scenes.lastSavedValues = paramdata.scenes.values;
+                }
             }
         }
     }
@@ -6717,21 +6677,10 @@ void HostConnector::initBlock(HostConnector::Block& blockdata,
     {
         Parameter& paramdata = blockdata.parameters[p];
         resetParameter(paramdata);
-        for (uint8_t s = 0; s < NUM_SCENES_PER_PRESET; ++s)
-        {
-            paramdata.scenes.values[s] = 0.f;
-            paramdata.scenes.lastSavedValues[s] = 0.f;
-        }
     }
 
     for (uint8_t p = numProps; p < MAX_PARAMS_PER_BLOCK; ++p)
         resetProperty(blockdata.properties[p]);
-
-    for (uint8_t s = 0; s < NUM_SCENES_PER_PRESET; ++s)
-    {
-        blockdata.scenes.enableValues[s] = true;
-        blockdata.scenes.lastSavedEnableValues[s] = true;
-    }
 
     // override defaults from user
     const std::string defdir = getDefaultPluginBundleForBlock(blockdata);
@@ -6802,14 +6751,15 @@ void HostConnector::initBlock(HostConnector::Block& blockdata,
         }
     }
 
-    for (uint8_t p = 0; p < numParams; ++p)
+    blockdata.scenes.enableValues.fill(true);
+    blockdata.scenes.lastSavedEnableValues.fill(true);
+
+    for (Parameter& paramdata : blockdata.parameters)
     {
-        Parameter& paramdata = blockdata.parameters[p];
-        for (uint8_t s = 0; s < NUM_SCENES_PER_PRESET; ++s)
-        {
-            paramdata.scenes.values[s] = blockdata.parameters[p].value;
-            paramdata.scenes.lastSavedValues[s] = blockdata.parameters[p].value;
-        }
+        if (isNullURI(paramdata.symbol))
+            break;
+        paramdata.scenes.values.fill(paramdata.value);
+        paramdata.scenes.lastSavedValues.fill(paramdata.value);
     }
 }
 
@@ -6842,11 +6792,8 @@ void HostConnector::resetBlock(Block& blockdata)
     for (uint8_t p = 0; p < MAX_PARAMS_PER_BLOCK; ++p)
         resetProperty(blockdata.properties[p]);
 
-    for (uint8_t s = 0; s < NUM_SCENES_PER_PRESET; ++s)
-    {
-        blockdata.scenes.enableValues[s] = false;
-        blockdata.scenes.lastSavedEnableValues[s] = false;
-    }
+    blockdata.scenes.enableValues.fill(false);
+    blockdata.scenes.lastSavedEnableValues.fill(false);
 }
 
 // --------------------------------------------------------------------------------------------------------------------
@@ -6919,11 +6866,8 @@ void HostConnector::setEnableChangesNotSavedToPreset(Block& blockdata, const boo
         --blockdata.meta.numParametersInScenes;
         blockdata.meta.enable.hasScenes = false;
     }
-    for (uint8_t s = 0; s < NUM_SCENES_PER_PRESET; ++s)
-    {
-        blockdata.scenes.enableValues[s] = blockdata.enabled;
-        blockdata.scenes.lastSavedEnableValues[s] = blockdata.enabled;
-    }
+    blockdata.scenes.enableValues.fill(blockdata.enabled);
+    blockdata.scenes.lastSavedEnableValues.fill(blockdata.enabled);
 }
 
 void HostConnector::setParamChangesNotSavedToPreset(Block& blockdata,
@@ -6946,11 +6890,8 @@ void HostConnector::setParamChangesNotSavedToPreset(Block& blockdata,
         --blockdata.meta.numParametersInScenes;
         paramdata.meta.flags &= ~Lv2ParameterInScene;
     }
-    for (uint8_t s = 0; s < NUM_SCENES_PER_PRESET; ++s)
-    {
-        paramdata.scenes.values[s] = paramdata.value;
-        paramdata.scenes.lastSavedValues[s] = paramdata.value;
-    }
+    paramdata.scenes.values.fill(paramdata.value);
+    paramdata.scenes.lastSavedValues.fill(paramdata.value);
 }
 
 // --------------------------------------------------------------------------------------------------------------------

--- a/src/connector.cpp
+++ b/src/connector.cpp
@@ -559,7 +559,7 @@ void HostConnector::printStateForDebug(const bool withBlocks, const bool withPar
                 fprintf(stderr, "\t\tnumSideOutputs: %u\n", blockdata.meta.numSideOutputs);
             }
 
-            for (uint8_t p = 0; p < MAX_PARAMS_PER_BLOCK && withParams; ++p)
+            for (uint8_t p = 0, size = blockdata.parameters.size(); p < size && withParams; ++p)
             {
                 const Parameter& paramdata(blockdata.parameters[p]);
 
@@ -584,7 +584,7 @@ void HostConnector::printStateForDebug(const bool withBlocks, const bool withPar
                 fprintf(stderr, "\t\t\tUnit: %s\n", paramdata.meta.unit.c_str());
             }
 
-            for (uint8_t p = 0; p < MAX_PARAMS_PER_BLOCK && withParams; ++p)
+            for (uint8_t p = 0, size = blockdata.properties.size(); p < size && withParams; ++p)
             {
                 const Property& propdata(blockdata.properties[p]);
 
@@ -1636,7 +1636,7 @@ bool HostConnector::replaceBlock(const uint8_t row,
                 hostPrerunBlockPair(hbp, LV2_KXSTUDIO_PROPERTIES_RESET_FULL, params);
             }
 
-            for (uint8_t p = 0; p < MAX_PARAMS_PER_BLOCK; ++p)
+            for (uint8_t p = 0, size = blockdata.properties.size(); p < size; ++p)
             {
                 Property& propdata(blockdata.properties[p]);
                 if (isNullURI(propdata.uri))
@@ -2014,7 +2014,7 @@ bool HostConnector::resetBlock(const uint8_t row, const uint8_t block, const boo
                 if (blockdataB.uri != blockdata.uri)
                     continue;
 
-                for (uint8_t p = 0; p < MAX_PARAMS_PER_BLOCK; ++p)
+                for (uint8_t p = 0, size = blockdata.parameters.size(); p < size; ++p)
                 {
                     Parameter& paramdata(blockdata.parameters[p]);
                     if (isNullURI(paramdata.symbol))
@@ -2075,7 +2075,7 @@ bool HostConnector::resetBlock(const uint8_t row, const uint8_t block, const boo
         hostPrerunBlockPair(hbp, LV2_KXSTUDIO_PROPERTIES_RESET_FULL, params);
     }
 
-    for (uint8_t p = 0; p < MAX_PARAMS_PER_BLOCK; ++p)
+    for (uint8_t p = 0, size = blockdata.properties.size(); p < size; ++p)
     {
         Property& propdata(blockdata.properties[p]);
         if (isNullURI(propdata.uri))
@@ -2115,7 +2115,7 @@ bool HostConnector::saveBlockStateAsDefault(const uint8_t row, const uint8_t blo
             if (blockdataB.uri != blockdata.uri)
                 continue;
 
-            for (uint8_t p = 0; p < MAX_PARAMS_PER_BLOCK; ++p)
+            for (uint8_t p = 0, size = blockdata.parameters.size(); p < size; ++p)
             {
                 Parameter& paramdata(blockdata.parameters[p]);
                 if (isNullURI(paramdata.symbol))
@@ -2718,6 +2718,7 @@ bool HostConnector::addBlockParameterBinding(const uint8_t hwid,
 
     Block& blockdata(_current.chains[row].blocks[block]);
     assert_return(!isNullBlock(blockdata), false);
+    assert_return(paramIndex < blockdata.parameters.size(), false);
 
     Parameter& paramdata(blockdata.parameters[paramIndex]);
     assert_return(!isNullURI(paramdata.symbol), false);
@@ -2816,6 +2817,7 @@ bool HostConnector::editBlockParameterBinding(const uint8_t hwid,
 
     Block& blockdata(_current.chains[row].blocks[block]);
     assert_return(!isNullBlock(blockdata), false);
+    assert_return(paramIndex < blockdata.parameters.size(), false);
 
     Parameter& paramdata(blockdata.parameters[paramIndex]);
     assert_return(!isNullURI(paramdata.symbol), false);
@@ -2942,6 +2944,7 @@ bool HostConnector::removeBlockParameterBinding(const uint8_t hwid,
 
     Block& blockdata(_current.chains[row].blocks[block]);
     assert_return(!isNullBlock(blockdata), false);
+    assert_return(paramIndex < blockdata.parameters.size(), false);
 
     Parameter& paramdata(blockdata.parameters[paramIndex]);
     assert_return(!isNullURI(paramdata.symbol), false);
@@ -3101,9 +3104,11 @@ bool HostConnector::replaceBlockParameterBinding(const uint8_t hwid,
 
     Block& blockdata(_current.chains[row].blocks[block]);
     assert_return(!isNullBlock(blockdata), false);
+    assert_return(paramIndex < blockdata.parameters.size(), false);
 
     Block& blockdataB(_current.chains[rowB].blocks[blockB]);
     assert_return(!isNullBlock(blockdataB), false);
+    assert_return(paramIndex < blockdataB.parameters.size(), false);
 
     Parameter& paramdata(blockdata.parameters[paramIndex]);
     assert_return(!isNullURI(paramdata.symbol), false);
@@ -3367,6 +3372,7 @@ void HostConnector::setBlockParameter(const uint8_t row,
 
     Block& blockdata(_current.chains[row].blocks[block]);
     assert_return(!isNullBlock(blockdata),);
+    assert_return(paramIndex < blockdata.parameters.size(),);
 
     const HostBlockPair hbp = _mapper.get(_current.preset, row, block);
     assert_return(hbp.id != kMaxHostInstances,);
@@ -3542,6 +3548,7 @@ void HostConnector::setBlockQuickPot(const uint8_t row, const uint8_t block, con
 
     Block& blockdata(_current.chains[row].blocks[block]);
     assert_return(!isNullBlock(blockdata),);
+    assert_return(paramIndex < blockdata.parameters.size(),);
 
     const Parameter& paramdata(blockdata.parameters[paramIndex]);
     assert_return(!isNullURI(paramdata.symbol),);
@@ -3565,6 +3572,7 @@ bool HostConnector::monitorBlockOutputParameter(const uint8_t row,
 
     const Block& blockdata(_current.chains[row].blocks[block]);
     assert_return(!isNullBlock(blockdata), false);
+    assert_return(paramIndex < blockdata.parameters.size(),);
 
     const HostBlockPair hbp = _mapper.get(_current.preset, row, block);
     assert_return(hbp.id != kMaxHostInstances, false);
@@ -3962,6 +3970,7 @@ void HostConnector::setBlockProperty(const uint8_t row,
 
     Block& blockdata(_current.chains[row].blocks[block]);
     assert_return(!isNullBlock(blockdata),);
+    assert_return(propIndex < blockdata.properties.size(),);
 
     const HostBlockPair hbp = _mapper.get(_current.preset, row, block);
     assert_return(hbp.id != kMaxHostInstances,);
@@ -5290,7 +5299,7 @@ void HostConnector::jsonPresetLoad(Preset& presetdata, const nlohmann::json& jpr
                         }
 
                         bool found = false;
-                        for (uint8_t p = 0; p < MAX_PARAMS_PER_BLOCK; ++p)
+                        for (uint8_t p = 0, size = blockdata.parameters.size(); p < size; ++p)
                         {
                             Parameter& paramdata = blockdata.parameters[p];
 
@@ -5591,7 +5600,7 @@ void HostConnector::jsonPresetSave(const Preset& presetdata, nlohmann::json& jpr
                 {
                     auto& jparams = jblock["parameters"];
 
-                    for (uint8_t p = 0, jp = 0; p < MAX_PARAMS_PER_BLOCK; ++p)
+                    for (uint8_t p = 0, jp = 0, size = blockdata.parameters.size(); p < size; ++p)
                     {
                         const Parameter& paramdata = blockdata.parameters[p];
 
@@ -5612,7 +5621,7 @@ void HostConnector::jsonPresetSave(const Preset& presetdata, nlohmann::json& jpr
                 {
                     auto& jprops = jblock["properties"];
 
-                    for (uint8_t p = 0, jp = 0; p < MAX_PARAMS_PER_BLOCK; ++p)
+                    for (uint8_t p = 0, jp = 0, size = blockdata.properties.size(); p < size; ++p)
                     {
                         const Property& propdata = blockdata.properties[p];
 
@@ -5944,6 +5953,11 @@ void HostConnector::hostSwitchPreset(const Preset& prev, const uint8_t prevPrese
                     if (isNullBlock(defblockdata))
                         continue;
 
+                    assert(defblockdata.parameters.size() == prevblockdata.parameters.size());
+                    assert(defblockdata.parameters.size() == inactblockdata.parameters.size());
+                    assert(defblockdata.properties.size() == prevblockdata.properties.size());
+                    assert(defblockdata.properties.size() == inactblockdata.properties.size());
+
                     const HostBlockPair hbp = _mapper.get(prevPreset, row, bl);
                     assert_continue(hbp.id != kMaxHostInstances);
 
@@ -5961,7 +5975,7 @@ void HostConnector::hostSwitchPreset(const Preset& prev, const uint8_t prevPrese
 
                     params.clear();
 
-                    for (uint8_t p = 0; p < MAX_PARAMS_PER_BLOCK; ++p)
+                    for (uint8_t p = 0, size = defblockdata.parameters.size(); p < size; ++p)
                     {
                         const Parameter& defparamdata(defblockdata.parameters[p]);
                         const Parameter& oldparamdata(prevblockdata.parameters[p]);
@@ -5991,7 +6005,7 @@ void HostConnector::hostSwitchPreset(const Preset& prev, const uint8_t prevPrese
                         params.push_back({ defparamdata.symbol.c_str(), defparamdata.value });
                     }
 
-                    for (uint8_t p = 0; p < MAX_PARAMS_PER_BLOCK; ++p)
+                    for (uint8_t p = 0, size = defblockdata.properties.size(); p < size; ++p)
                     {
                         const Property& defpropdata(defblockdata.properties[p]);
                         const Property& prevpropdata(prevblockdata.properties[p]);
@@ -6268,7 +6282,8 @@ void HostConnector::hostFeedbackCallback(const HostFeedbackData& data)
                 Block& blockdata = _current.chains[hbar.row].blocks[hbar.block];
 
                 uint8_t p = 0;
-                for (; p < MAX_PARAMS_PER_BLOCK; ++p)
+                uint8_t size = blockdata.parameters.size();
+                for (; p < size; ++p)
                 {
                     if (isNullURI(blockdata.parameters[p].symbol))
                         return;
@@ -6276,7 +6291,7 @@ void HostConnector::hostFeedbackCallback(const HostFeedbackData& data)
                         break;
                 }
 
-                if (p == MAX_PARAMS_PER_BLOCK)
+                if (p == size)
                     return;
 
                 if (data.type == HostFeedbackData::kFeedbackParameterSet)
@@ -6312,15 +6327,16 @@ void HostConnector::hostFeedbackCallback(const HostFeedbackData& data)
                                                          : _presets[preset].chains[hbar.row].blocks[hbar.block];
 
             uint8_t p = 0;
-            for (; p < MAX_PARAMS_PER_BLOCK; ++p)
+            uint8_t size = blockdata.parameters.size();
+            for (; p < size; ++p)
             {
                 if (isNullURI(blockdata.parameters[p].symbol))
-                    p = MAX_PARAMS_PER_BLOCK;
+                    p = size;
                 if (blockdata.parameters[p].symbol == data.paramState.symbol)
                     break;
             }
 
-            if (p == MAX_PARAMS_PER_BLOCK)
+            if (p == size)
                 break;
 
             const Lv2ParameterState stateValue = static_cast<Lv2ParameterState>(data.paramState.value);

--- a/src/connector.cpp
+++ b/src/connector.cpp
@@ -4942,9 +4942,9 @@ void HostConnector::jsonPresetLoad(Preset& presetdata, const nlohmann::json& jpr
                         if ((paramdata.meta.flags & Lv2ParameterNotAllowedToChange) != 0)
                             continue;
 
-                        paramdata.value = std::max(paramdata.meta.min,
-                                                    std::min<float>(paramdata.meta.max,
-                                                                    jparam["value"].get<double>()));
+                        paramdata.value = std::clamp<float>(jparam["value"].get<double>(),
+                                                            paramdata.meta.min,
+                                                            paramdata.meta.max);
 
                         paramdata.scenes.values.fill(paramdata.value);
                     }
@@ -5088,8 +5088,9 @@ void HostConnector::jsonPresetLoad(Preset& presetdata, const nlohmann::json& jpr
                                         ++blockdata.meta.numParametersInScenes;
                                     }
 
-                                    paramdata.scenes.values[s] =
-                                        std::max(paramdata.meta.min, std::min<float>(paramdata.meta.max, value));
+                                    paramdata.scenes.values[s] = std::clamp<float>(value,
+                                                                                   paramdata.meta.min,
+                                                                                   paramdata.meta.max);
                                 }
                             }
                         }
@@ -5369,7 +5370,7 @@ void HostConnector::jsonPresetLoad(Preset& presetdata, const nlohmann::json& jpr
                     continue;
                 }
 
-                bindings.value = std::max(0.0, std::min(1.0, jvalue));
+                bindings.value = std::clamp(jvalue, 0.0, 1.0);
             }
             else
             {

--- a/src/connector.cpp
+++ b/src/connector.cpp
@@ -1013,9 +1013,8 @@ bool HostConnector::saveCurrentPresetToFile(const char* const filename)
                 }
                 blockdata.meta.enable.tempSceneState = kTemporarySceneNone;
 
-                for (uint8_t p = 0; p < MAX_PARAMS_PER_BLOCK; ++p)
+                for (Parameter& paramdata : blockdata.parameters)
                 {
-                    Parameter& paramdata(blockdata.parameters[p]);
                     if (isNullURI(paramdata.symbol))
                         break;
                     if ((paramdata.meta.flags & Lv2ParameterNotAllowedInScenes) != 0)
@@ -1752,9 +1751,8 @@ bool HostConnector::replaceBlock(const uint8_t row,
 
                 // TODO: check if also needed for regular replace case
                 // previously used only in replaceBlockWhileKeepingData
-                for (uint8_t p = 0; p < MAX_PARAMS_PER_BLOCK; ++p)
+                for (const Property& propdata : blockdata.properties)
                 {
-                    const Property& propdata(blockdata.properties[p]);
                     if (isNullURI(propdata.uri))
                         break;
                     if ((propdata.meta.flags & Lv2PropertyNotAllowedToChange) != 0)
@@ -1769,9 +1767,8 @@ bool HostConnector::replaceBlock(const uint8_t row,
                 initBlock(blockdata, plugin, numInputs, numOutputs, numSideInputs, numSideOutputs);
             }
 
-            for (uint8_t p = 0; p < MAX_PARAMS_PER_BLOCK; ++p)
+            for (Parameter& paramdata : blockdata.parameters)
             {
-                Parameter& paramdata(blockdata.parameters[p]);
                 if (isNullURI(paramdata.symbol))
                     break;
                 if ((paramdata.meta.flags & Lv2ParameterNotAllowedToChange) != 0)
@@ -1783,7 +1780,7 @@ bool HostConnector::replaceBlock(const uint8_t row,
                 
                 // initialize states, because there will be no updates on initial Lv2ParameterStateNone state
                 if (keepCurrentData)
-                    blockdata.parameters[p].meta.state = Lv2ParameterStateNone;
+                    paramdata.meta.state = Lv2ParameterStateNone;
             }
 
             hostPrerunBlockPair(hbp, LV2_KXSTUDIO_PROPERTIES_RESET_FULL, params);
@@ -2047,9 +2044,8 @@ bool HostConnector::resetBlock(const uint8_t row, const uint8_t block, const boo
         } while (false);
     }
 
-    for (uint8_t p = 0; p < MAX_PARAMS_PER_BLOCK; ++p)
-    {
-        Parameter& paramdata(blockdata.parameters[p]);
+    for (Parameter& paramdata : blockdata.parameters)
+    {;
         if (isNullURI(paramdata.symbol))
             break;
         if ((paramdata.meta.flags & Lv2ParameterNotAllowedToChange) != 0)
@@ -2539,9 +2535,8 @@ bool HostConnector::switchScene(const uint8_t scene)
                 hostBypassBlockPair(hbp, true);
             }
 
-            for (uint8_t p = 0; p < MAX_PARAMS_PER_BLOCK; ++p)
+            for (Parameter& paramdata : blockdata.parameters)
             {
-                Parameter& paramdata(blockdata.parameters[p]);
                 if (isNullURI(paramdata.symbol))
                     break;
                 if ((paramdata.meta.flags & Lv2ParameterNotAllowedInScenes) != 0)
@@ -3213,9 +3208,8 @@ bool HostConnector::reorderBlockBinding(const uint8_t hwid, const uint8_t dest)
                 else if (blockdata.meta.enable.hwbinding == hwidB)
                     blockdata.meta.enable.hwbinding = hwidA;
 
-                for (uint8_t p = 0; p < MAX_PARAMS_PER_BLOCK; ++p)
+                for (Parameter& paramdata : blockdata.parameters)
                 {
-                    Parameter& paramdata(blockdata.parameters[p]);
                     if (isNullURI(paramdata.symbol))
                         break;
 
@@ -5652,10 +5646,8 @@ void HostConnector::jsonPresetSave(const Preset& presetdata, nlohmann::json& jpr
                         {
                             auto& jsceneparams = jscene["parameters"];
 
-                            for (uint8_t p = 0; p < MAX_PARAMS_PER_BLOCK; ++p)
+                            for (const Parameter& paramdata : blockdata.parameters)
                             {
-                                const Parameter& paramdata = blockdata.parameters[p];
-
                                 if (isNullURI(paramdata.symbol))
                                     break;
                                 if (! shouldSaveParameterToPreset(paramdata.meta.flags))
@@ -6041,9 +6033,8 @@ void HostConnector::hostSwitchPreset(const Preset& prev, const uint8_t prevPrese
 
                 params.clear();
 
-                for (uint8_t p = 0; p < MAX_PARAMS_PER_BLOCK; ++p)
+                for (const Parameter& defparamdata : defblockdata.parameters)
                 {
-                    const Parameter& defparamdata(defblockdata.parameters[p]);
                     if (isNullURI(defparamdata.symbol))
                         break;
                     if ((defparamdata.meta.flags & Lv2ParameterNotAllowedToChange) != 0)
@@ -6054,9 +6045,8 @@ void HostConnector::hostSwitchPreset(const Preset& prev, const uint8_t prevPrese
                     params.push_back({ defparamdata.symbol.c_str(), defparamdata.value });
                 }
 
-                for (uint8_t p = 0; p < MAX_PARAMS_PER_BLOCK; ++p)
+                for (const Property& defpropdata : defblockdata.properties)
                 {
-                    const Property& defpropdata(defblockdata.properties[p]);
                     if (isNullURI(defpropdata.uri))
                         break;
                     if ((defpropdata.meta.flags & Lv2PropertyNotAllowedToChange) != 0)
@@ -6786,11 +6776,11 @@ void HostConnector::resetBlock(Block& blockdata)
     blockdata.meta.abbreviation.clear();
     blockdata.meta.category = kLv2CategoryNone;
 
-    for (uint8_t p = 0; p < MAX_PARAMS_PER_BLOCK; ++p)
-        resetParameter(blockdata.parameters[p]);
+    for (Parameter& paramdata : blockdata.parameters)
+        resetParameter(paramdata);
 
-    for (uint8_t p = 0; p < MAX_PARAMS_PER_BLOCK; ++p)
-        resetProperty(blockdata.properties[p]);
+    for (Property& propdata : blockdata.properties)
+        resetProperty(propdata);
 
     blockdata.scenes.enableValues.fill(false);
     blockdata.scenes.lastSavedEnableValues.fill(false);

--- a/src/connector.hpp
+++ b/src/connector.hpp
@@ -250,8 +250,8 @@ struct HostConnector : Host::FeedbackCallback {
             // convenience meta-data, not stored in json state
             // TODO remove details directly provided by plugin data
             struct {
-                bool hasScenes;
                 bool changesNotSavedToPreset;
+                bool hasScenes;
                 uint8_t hwbinding;
                 TemporarySceneState tempSceneState;
             } enable;
@@ -384,6 +384,7 @@ struct HostConnector : Host::FeedbackCallback {
             return chains[0].blocks[block];
         }
        #endif
+        CLASS_ONLY_MOVE_INIT_NO_COPY(Current)
     };
 
     // connection to mod-host, handled internally

--- a/src/connector.hpp
+++ b/src/connector.hpp
@@ -200,6 +200,11 @@ struct HostConnector : Host::FeedbackCallback {
             std::vector<Lv2ScalePoint> scalePoints;
             CLASS_ONLY_MOVE_INIT_NO_COPY(Meta)
         } meta;
+        struct Scenes {
+            heap_array<float, NUM_SCENES_PER_PRESET> values;
+            heap_array<float, NUM_SCENES_PER_PRESET> lastSavedValues;
+            CLASS_ONLY_MOVE_INIT_NO_COPY(Scenes)
+        } scenes;
         CLASS_ONLY_MOVE_INIT_NO_COPY(Parameter)
     };
 
@@ -236,12 +241,6 @@ struct HostConnector : Host::FeedbackCallback {
         SceneModeUpdateTemporarily,
     };
 
-    struct SceneValues {
-        bool enabled;
-        heap_array<float, MAX_PARAMS_PER_BLOCK> parameters;
-        CLASS_ONLY_MOVE_INIT_NO_COPY(SceneValues)
-    };
-
     struct Block {
         bool enabled;
         std::string quickPotSymbol;
@@ -268,9 +267,12 @@ struct HostConnector : Host::FeedbackCallback {
             Lv2Category category;
             CLASS_ONLY_MOVE_INIT_NO_COPY(Meta)
         } meta;
+        struct Scenes {
+            heap_array<bool, NUM_SCENES_PER_PRESET> enableValues;
+            heap_array<bool, NUM_SCENES_PER_PRESET> lastSavedEnableValues;
+        } scenes;
         heap_array<Parameter, MAX_PARAMS_PER_BLOCK> parameters;
         heap_array<Property, MAX_PARAMS_PER_BLOCK> properties;
-        heap_array<SceneValues, NUM_SCENES_PER_PRESET> sceneValues;
 
         // keep hold of plugin data
         std::shared_ptr<const Lv2Plugin> plugin;
@@ -294,9 +296,7 @@ struct HostConnector : Host::FeedbackCallback {
         }
 
     private:
-        // extra details, not stored in json state
         friend struct HostConnector;
-        heap_array<SceneValues, NUM_SCENES_PER_PRESET> lastSavedSceneValues;
         std::unordered_map<std::string, uint8_t> parameterSymbolToIndexMap;
         std::unordered_map<std::string, uint8_t> propertyURIToIndexMap;
         CLASS_ONLY_MOVE_INIT_NO_COPY(Block)

--- a/src/connector.hpp
+++ b/src/connector.hpp
@@ -57,6 +57,12 @@ public:
     // do not allow copy constructor
     heap_array(const heap_array&) = delete;
 
+    // std::array-like methods
+    void fill(const T& value)
+    {
+        std::fill(std::vector<T>::begin(), std::vector<T>::end(), value);
+    }
+
     // unwanted methods, trying to force fixed size
     void append_range() = delete;
     void clear() = delete;


### PR DESCRIPTION
This is a general cleanup in preparation for expanded scenes, in this PR we have:
- moving where scene data is stored, no longer having a global 2-dimensional array for `sceneValues` but we store data together with the block (for enable/bypass state scenes) and parameters; this is a preparation for an upcoming PR where only the needed parameters are allocated, instead of always using `MAX_PARAMS_PER_BLOCK`
- use `<scenestuff>.fill(value)` instead of manual for loop (potentially works faster? I didnt test)
- remove some use of `MAX_PARAMS_PER_BLOCK` (more to come after this PR)
- use loop iterators instead of manual indexes where possible
- a little bit of cleanup where relevant

The individual commits are self-contained so they are easy to review.
