### PR TITLE
Expanded scenes

### DIFF
--- a/src/config.h
+++ b/src/config.h
@@ -98,3 +98,30 @@
 
 #define MOD_HOST_EFFECT_PREFIX "effect_"
 #define MOD_HOST_EFFECT_PREFIX_LEN 7
+
+// --------------------------------------------------------------------------------------------------------------------
+// test known configuration
+
+#ifdef _DARKGLASS_DEVICE_PABLITO
+
+#if NUM_BINDING_ACTUATORS != 10
+#error wrong NUM_BINDING_ACTUATORS
+#endif
+
+#if NUM_PRESETS_PER_BANK != 3
+#error wrong NUM_PRESETS_PER_BANK
+#endif
+
+#if NUM_SCENES_PER_PRESET != 126
+#error wrong NUM_SCENES_PER_PRESET
+#endif
+
+#if NUM_BLOCKS_PER_PRESET != 12
+#error wrong NUM_BLOCKS_PER_PRESET
+#endif
+
+#if NUM_BLOCK_CHAIN_ROWS != 2
+#error NUM_BLOCK_CHAIN_ROWS
+#endif
+
+#endif

--- a/src/connector.cpp
+++ b/src/connector.cpp
@@ -262,18 +262,18 @@ static constexpr const char* SceneMode2Str(const HostSceneMode sceneMode)
 {
     switch (sceneMode)
     {
-    case HostConnector::SceneModeActivate:
-        return "SceneModeActivate";
-    case HostConnector::SceneModeClear:
-        return "SceneModeClear";
-    case HostConnector::SceneModeUpdate:
-        return "SceneModeUpdate";
-    case HostConnector::SceneModeActivateTemporarily:
-        return "SceneModeActivateTemporarily";
-    case HostConnector::SceneModeClearTemporarily:
-        return "SceneModeClearTemporarily";
-    case HostConnector::SceneModeUpdateTemporarily:
-        return "SceneModeUpdateTemporarily";
+    case HostConnector::kSceneModeActivate:
+        return "kSceneModeActivate";
+    case HostConnector::kSceneModeClear:
+        return "kSceneModeClear";
+    case HostConnector::kSceneModeUpdate:
+        return "kSceneModeUpdate";
+    case HostConnector::kSceneModeActivateTemporarily:
+        return "kSceneModeActivateTemporarily";
+    case HostConnector::kSceneModeClearTemporarily:
+        return "kSceneModeClearTemporarily";
+    case HostConnector::kSceneModeUpdateTemporarily:
+        return "kSceneModeUpdateTemporarily";
     }
 
     return "";
@@ -1313,7 +1313,7 @@ bool HostConnector::enableBlock(const uint8_t row, const uint8_t block, const bo
 
         switch (sceneMode)
         {
-        case SceneModeActivate:
+        case kSceneModeActivate:
             if (! blockdata.meta.enable.hasScenes)
             {
                 ++blockdata.meta.numParametersInScenes;
@@ -1333,7 +1333,7 @@ bool HostConnector::enableBlock(const uint8_t row, const uint8_t block, const bo
             blockdata.scenes.lastSavedEnableValues[_current.scene] = enable;
             break;
 
-        case SceneModeActivateTemporarily:
+        case kSceneModeActivateTemporarily:
             if (! blockdata.meta.enable.hasScenes)
             {
                 ++blockdata.meta.numParametersInScenes;
@@ -1356,7 +1356,7 @@ bool HostConnector::enableBlock(const uint8_t row, const uint8_t block, const bo
             blockdata.scenes.enableValues[_current.scene] = enable;
             break;
 
-        case SceneModeClear:
+        case kSceneModeClear:
             if (blockdata.meta.enable.hasScenes)
             {
                 --blockdata.meta.numParametersInScenes;
@@ -1366,7 +1366,7 @@ bool HostConnector::enableBlock(const uint8_t row, const uint8_t block, const bo
             blockdata.scenes.lastSavedEnableValues.fill(enable);
             break;
 
-        case SceneModeClearTemporarily:
+        case kSceneModeClearTemporarily:
             if (blockdata.meta.enable.hasScenes)
             {
                 --blockdata.meta.numParametersInScenes;
@@ -1380,7 +1380,7 @@ bool HostConnector::enableBlock(const uint8_t row, const uint8_t block, const bo
             blockdata.scenes.enableValues.fill(enable);
             break;
 
-        case SceneModeUpdate:
+        case kSceneModeUpdate:
             if (! blockdata.meta.enable.hasScenes)
             {
                 blockdata.scenes.enableValues.fill(enable);
@@ -1393,12 +1393,19 @@ bool HostConnector::enableBlock(const uint8_t row, const uint8_t block, const bo
             }
             break;
 
-        case SceneModeUpdateTemporarily:
+        case kSceneModeUpdateTemporarily:
             if (! blockdata.meta.enable.hasScenes)
                 blockdata.scenes.enableValues.fill(enable);
             else
                 blockdata.scenes.enableValues[_current.scene] = enable;
             break;
+        }
+
+        if (_current.scenes[_current.scene].state == kSceneInUseTemporarily &&
+            blockdata.meta.enable.hasScenes &&
+            blockdata.meta.enable.tempSceneState == kTemporarySceneNone)
+        {
+            _current.scenes[_current.scene].state = kSceneInUse;
         }
     }
 
@@ -2375,9 +2382,9 @@ void HostConnector::clearAllScenes()
 
     for (uint8_t s = 0; s < NUM_SCENES_PER_PRESET; ++s)
     {
-        if (_current.scenes[s].active)
+        if (_current.scenes[s].state != HostConnector::kSceneUnused)
             continue;
-        _current.scenes[s].active = false;
+        _current.scenes[s].state = HostConnector::kSceneUnused;
         _current.scenes[s].name.clear();
         modified = true;
     }
@@ -2418,10 +2425,10 @@ void HostConnector::clearScene(const uint8_t scene)
     mod_log_debug("clearScene(%u)", scene);
     assert(scene < NUM_SCENES_PER_PRESET);
 
-    if (! _current.scenes[scene].active)
+    if (_current.scenes[scene].state == HostConnector::kSceneUnused)
         return;
 
-    _current.scenes[scene].active = false;
+    _current.scenes[scene].state = HostConnector::kSceneUnused;
     _current.scenes[scene].name.clear();
 
     _current.dirty = true;
@@ -2441,10 +2448,16 @@ bool HostConnector::copyScene(const uint8_t orig, const uint8_t dest)
         return false;
     }
 
-    if (_current.scenes[orig].active)
+    if (_current.scenes[orig].state != HostConnector::kSceneUnused)
+    {
+        _current.scenes[dest].name = _current.scenes[orig].name;
+        _current.scenes[dest].state = HostConnector::kSceneInUse;
         copySceneData(orig, dest);
+    }
     else
+    {
         clearScene(dest);
+    }
 
     _current.dirty = true;
     return true;
@@ -2615,16 +2628,23 @@ bool HostConnector::switchScene(const uint8_t scene, const bool discardPrevious)
     }
 
     const uint8_t previousScene = _current.scene;
-    const bool previousSceneWasActive =_current.scenes[previousScene].active;
-    const bool activateNewScene = !_current.scenes[scene].active;
+    const SceneState previousSceneState =_current.scenes[previousScene].state;
+
+    if (previousSceneState == kSceneInUseTemporarily)
+        _current.scenes[previousScene].state = kSceneUnused;
+
+    const bool activateNewScene = _current.scenes[scene].state == kSceneUnused;
 
     _current.scene = scene;
 
     if (activateNewScene)
     {
-        _current.scenes[scene].active = true;
         _current.scenes[scene].name = _current.scenes[previousScene].name;
+        _current.scenes[scene].state = kSceneInUseTemporarily;
     }
+
+    bool blockEnabled;
+    float paramValue;
 
     const Host::NonBlockingScope hnbs(_host);
 
@@ -2642,9 +2662,18 @@ bool HostConnector::switchScene(const uint8_t scene, const bool discardPrevious)
 
             params.clear();
 
-            const bool blockEnabled = previousSceneWasActive
-                                    ? blockdata.scenes.lastSavedEnableValues[previousScene]
-                                    : blockdata.enabled;
+            switch (previousSceneState)
+            {
+            case kSceneUnused:
+                blockEnabled = blockdata.enabled;
+                break;
+            case kSceneInUse:
+                blockEnabled = blockdata.scenes.enableValues[previousScene];
+                break;
+            case kSceneInUseTemporarily:
+                blockEnabled = blockdata.scenes.lastSavedEnableValues[previousScene];
+                break;
+            }
 
             // revert temp scene state
             switch (blockdata.meta.enable.tempSceneState)
@@ -2681,9 +2710,18 @@ bool HostConnector::switchScene(const uint8_t scene, const bool discardPrevious)
                 if ((paramdata.meta.flags & Lv2ParameterNotAllowedInScenes) != 0)
                     continue;
 
-                const float value = previousSceneWasActive
-                                  ? paramdata.scenes.lastSavedValues[previousScene]
-                                  : paramdata.value;
+                switch (previousSceneState)
+                {
+                case kSceneUnused:
+                    paramValue = paramdata.value;
+                    break;
+                case kSceneInUse:
+                    paramValue = paramdata.scenes.values[previousScene];
+                    break;
+                case kSceneInUseTemporarily:
+                    paramValue = paramdata.scenes.lastSavedValues[previousScene];
+                    break;
+                }
 
                 // revert temp scene state
                 switch (paramdata.meta.tempSceneState)
@@ -2695,25 +2733,25 @@ bool HostConnector::switchScene(const uint8_t scene, const bool discardPrevious)
                     --blockdata.meta.numParametersInScenes;
                     paramdata.meta.flags &= ~Lv2ParameterInScene;
                     paramdata.meta.tempSceneState = kTemporarySceneNone;
-                    paramdata.scenes.values[previousScene] = value;
+                    paramdata.scenes.values[previousScene] = paramValue;
                     break;
                 case kTemporarySceneClear:
                     assert((paramdata.meta.flags & Lv2ParameterInScene) == 0);
                     ++blockdata.meta.numParametersInScenes;
                     paramdata.meta.flags |= Lv2ParameterInScene;
                     paramdata.meta.tempSceneState = kTemporarySceneNone;
-                    paramdata.scenes.values[previousScene] = value;
+                    paramdata.scenes.values[previousScene] = paramValue;
                     break;
                 }
 
-                if (isNotEqual(paramdata.value, value))
+                if (isNotEqual(paramdata.value, paramValue))
                 {
-                    paramdata.value = value;
+                    paramdata.value = paramValue;
                     params.push_back({ paramdata.symbol.c_str(), paramdata.value });
                 }
 
                 if (activateNewScene)
-                    paramdata.scenes.values[scene] = paramdata.scenes.lastSavedValues[scene] = value;
+                    paramdata.scenes.values[scene] = paramdata.scenes.lastSavedValues[scene] = paramValue;
             }
 
             hostParamsFlushBlockPair(hbp, LV2_KXSTUDIO_PROPERTIES_RESET_NONE, params);
@@ -2798,12 +2836,12 @@ bool HostConnector::renameScene(const uint8_t scene, const char* const name)
     if (_current.scenes[scene].name == name)
         return false;
 
-    if (! _current.scenes[scene].active)
+    if (_current.scenes[scene].state == HostConnector::kSceneUnused)
     {
-        if (_current.scenes[_current.scene].active)
+        _current.scenes[scene].state = HostConnector::kSceneInUse;
+
+        if (_current.scenes[_current.scene].state != HostConnector::kSceneUnused)
             copySceneData(_current.scene, scene);
-        else
-            _current.scenes[scene].active = true;
     }
 
     _current.dirty = true;
@@ -3226,7 +3264,7 @@ bool HostConnector::replaceBlockBinding(const uint8_t hwid,
         else
         {
             // update block to match binding macro
-            enableBlock(rowB, blockB, _current.bindings[hwid].value > 0.5f, SceneModeUpdate);
+            enableBlock(rowB, blockB, _current.bindings[hwid].value > 0.5f, kSceneModeUpdate);
         }
 
         _current.dirty = true;
@@ -3327,7 +3365,7 @@ bool HostConnector::replaceBlockParameterBinding(const uint8_t hwid,
         {
             // update parameter value to match binding macro
             const float value = unnormalized(paramdataB.meta, _current.bindings[hwid].value);
-            setBlockParameter(rowB, blockB, paramIndexB, value, SceneModeUpdate);
+            setBlockParameter(rowB, blockB, paramIndexB, value, kSceneModeUpdate);
         }
 
         _current.dirty = true;
@@ -3546,7 +3584,7 @@ void HostConnector::setBlockParameter(const uint8_t row,
     {
         switch (sceneMode)
         {
-        case SceneModeActivate:
+        case kSceneModeActivate:
             if ((paramdata.meta.flags & Lv2ParameterInScene) == 0)
             {
                 ++blockdata.meta.numParametersInScenes;
@@ -3566,7 +3604,7 @@ void HostConnector::setBlockParameter(const uint8_t row,
             paramdata.scenes.lastSavedValues[_current.scene] = value;
             break;
 
-        case SceneModeActivateTemporarily:
+        case kSceneModeActivateTemporarily:
             if ((paramdata.meta.flags & Lv2ParameterInScene) == 0)
             {
                 ++blockdata.meta.numParametersInScenes;
@@ -3589,7 +3627,7 @@ void HostConnector::setBlockParameter(const uint8_t row,
             paramdata.scenes.values[_current.scene] = value;
             break;
 
-        case SceneModeClear:
+        case kSceneModeClear:
             if ((paramdata.meta.flags & Lv2ParameterInScene) != 0)
             {
                 --blockdata.meta.numParametersInScenes;
@@ -3599,7 +3637,7 @@ void HostConnector::setBlockParameter(const uint8_t row,
             paramdata.scenes.lastSavedValues.fill(value);
             break;
 
-        case SceneModeClearTemporarily:
+        case kSceneModeClearTemporarily:
             if ((paramdata.meta.flags & Lv2ParameterInScene) != 0)
             {
                 --blockdata.meta.numParametersInScenes;
@@ -3613,7 +3651,7 @@ void HostConnector::setBlockParameter(const uint8_t row,
             paramdata.scenes.values.fill(value);
             break;
 
-        case SceneModeUpdate:
+        case kSceneModeUpdate:
             if ((paramdata.meta.flags & Lv2ParameterInScene) == 0)
             {
                 paramdata.scenes.values.fill(value);
@@ -3626,12 +3664,19 @@ void HostConnector::setBlockParameter(const uint8_t row,
             }
             break;
 
-        case SceneModeUpdateTemporarily:
+        case kSceneModeUpdateTemporarily:
             if ((paramdata.meta.flags & Lv2ParameterInScene) == 0)
                 paramdata.scenes.values.fill(value);
             else
                 paramdata.scenes.values[_current.scene] = value;
             break;
+        }
+
+        if (_current.scenes[_current.scene].state == kSceneInUseTemporarily &&
+            (paramdata.meta.flags & Lv2ParameterInScene) != 0 &&
+            paramdata.meta.tempSceneState == kTemporarySceneNone)
+        {
+            _current.scenes[_current.scene].state = kSceneInUse;
         }
 
         if (paramdata.meta.hwbinding != UINT8_MAX)
@@ -4115,11 +4160,10 @@ void HostConnector::monitorToolOutputParameter(const uint8_t toolIndex, const ch
 void HostConnector::setBlockProperty(const uint8_t row,
                                      const uint8_t block,
                                      const uint8_t propIndex,
-                                     const char* const value,
-                                     const SceneMode sceneMode)
+                                     const char* const value)
 {
-    mod_log_debug("setBlockProperty(%u, %u, %u, \"%s\", %d:%s)",
-                  row, block, propIndex, value, sceneMode, SceneMode2Str(sceneMode));
+    mod_log_debug("setBlockProperty(%u, %u, %u, \"%s\")",
+                  row, block, propIndex, value);
     assert(row < NUM_BLOCK_CHAIN_ROWS);
     assert(block < NUM_BLOCKS_PER_PRESET);
     assert(propIndex < MAX_PARAMS_PER_BLOCK);
@@ -4148,11 +4192,10 @@ void HostConnector::setBlockProperty(const uint8_t row,
 void HostConnector::setBlockProperty(const uint8_t row,
                                      const uint8_t block,
                                      const char* const uri,
-                                     const char* const value,
-                                     const SceneMode sceneMode)
+                                     const char* const value)
 {
-    mod_log_debug("setBlockProperty(%u, %u, \"%s\", \"%s\", %d:%s)",
-                  row, block, uri, value, sceneMode, SceneMode2Str(sceneMode));
+    mod_log_debug("setBlockProperty(%u, %u, \"%s\", \"%s\")",
+                  row, block, uri, value);
     assert(row < NUM_BLOCK_CHAIN_ROWS);
     assert(block < NUM_BLOCKS_PER_PRESET);
     assert(uri != nullptr && *uri != '\0');
@@ -4169,7 +4212,7 @@ void HostConnector::setBlockProperty(const uint8_t row,
         return;
     }
 
-    setBlockProperty(row, block, propIndex, value, sceneMode);
+    setBlockProperty(row, block, propIndex, value);
 }
 
 // --------------------------------------------------------------------------------------------------------------------
@@ -5193,7 +5236,7 @@ void HostConnector::jsonPresetLoad(Preset& presetdata, const nlohmann::json& jpr
                                 }
 
                                 blockdata.scenes.enableValues[s] = enabled;
-                                presetdata.scenes[s].active = true;
+                                presetdata.scenes[s].state = HostConnector::kSceneInUse;
                             }
                         }
 
@@ -5258,7 +5301,7 @@ void HostConnector::jsonPresetLoad(Preset& presetdata, const nlohmann::json& jpr
                                     paramdata.scenes.values[s] = std::clamp<float>(value,
                                                                                    paramdata.meta.min,
                                                                                    paramdata.meta.max);
-                                    presetdata.scenes[s].active = true;
+                                    presetdata.scenes[s].state = HostConnector::kSceneInUse;
                                 }
                             }
                         }
@@ -6714,10 +6757,7 @@ void HostConnector::copySceneData(uint8_t orig, uint8_t dest)
 {
     assert(orig < NUM_SCENES_PER_PRESET);
     assert(dest < NUM_SCENES_PER_PRESET);
-    assert(_current.scenes[orig].active);
-
-    _current.scenes[dest].active = true;
-    _current.scenes[dest].name = _current.scenes[orig].name;
+    assert(_current.scenes[orig].state != HostConnector::kSceneUnused);
 
     for (uint8_t row = 0; row < NUM_BLOCK_CHAIN_ROWS; ++row)
     {
@@ -7052,7 +7092,7 @@ void HostConnector::resetPreset(Preset& preset)
 
     for (uint8_t s = 0; s < NUM_SCENES_PER_PRESET; ++s)
     {
-        preset.scenes[s].active = false;
+        preset.scenes[s].state = HostConnector::kSceneUnused;
         preset.scenes[s].name.clear();
     }
 }

--- a/src/connector.cpp
+++ b/src/connector.cpp
@@ -1331,6 +1331,7 @@ bool HostConnector::enableBlock(const uint8_t row, const uint8_t block, const bo
             // set new value for current scene
             blockdata.scenes.enableValues[_current.scene] = enable;
             blockdata.scenes.lastSavedEnableValues[_current.scene] = enable;
+            assert(blockdata.meta.enable.tempSceneState == kTemporarySceneNone);
             break;
 
         case kSceneModeActivateTemporarily:
@@ -1364,6 +1365,7 @@ bool HostConnector::enableBlock(const uint8_t row, const uint8_t block, const bo
             }
             blockdata.scenes.enableValues.fill(enable);
             blockdata.scenes.lastSavedEnableValues.fill(enable);
+            assert(blockdata.meta.enable.tempSceneState == kTemporarySceneNone);
             break;
 
         case kSceneModeClearTemporarily:
@@ -1391,6 +1393,7 @@ bool HostConnector::enableBlock(const uint8_t row, const uint8_t block, const bo
                 blockdata.scenes.enableValues[_current.scene] = enable;
                 blockdata.scenes.lastSavedEnableValues[_current.scene] = enable;
             }
+            assert(blockdata.meta.enable.tempSceneState == kTemporarySceneNone);
             break;
 
         case kSceneModeUpdateTemporarily:
@@ -1401,12 +1404,8 @@ bool HostConnector::enableBlock(const uint8_t row, const uint8_t block, const bo
             break;
         }
 
-        if (_current.scenes[_current.scene].state == kSceneInUseTemporarily &&
-            blockdata.meta.enable.hasScenes &&
-            blockdata.meta.enable.tempSceneState == kTemporarySceneNone)
-        {
+        if (blockdata.meta.enable.hasScenes && blockdata.meta.enable.tempSceneState == kTemporarySceneNone)
             _current.scenes[_current.scene].state = kSceneInUse;
-        }
     }
 
     if (blockdata.meta.enable.hwbinding != UINT8_MAX)
@@ -2628,9 +2627,8 @@ bool HostConnector::switchScene(const uint8_t scene, const bool discardPrevious)
     }
 
     const uint8_t previousScene = _current.scene;
-    const SceneState previousSceneState =_current.scenes[previousScene].state;
 
-    if (previousSceneState == kSceneInUseTemporarily)
+    if (_current.scenes[previousScene].state == kSceneInUseTemporarily)
         _current.scenes[previousScene].state = kSceneUnused;
 
     const bool activateNewScene = _current.scenes[scene].state == kSceneUnused;
@@ -2662,18 +2660,7 @@ bool HostConnector::switchScene(const uint8_t scene, const bool discardPrevious)
 
             params.clear();
 
-            switch (previousSceneState)
-            {
-            case kSceneUnused:
-                blockEnabled = blockdata.enabled;
-                break;
-            case kSceneInUse:
-                blockEnabled = blockdata.scenes.enableValues[previousScene];
-                break;
-            case kSceneInUseTemporarily:
-                blockEnabled = blockdata.scenes.lastSavedEnableValues[previousScene];
-                break;
-            }
+            blockEnabled = activateNewScene ? blockdata.enabled : blockdata.scenes.enableValues[scene];
 
             // revert temp scene state
             switch (blockdata.meta.enable.tempSceneState)
@@ -2685,14 +2672,14 @@ bool HostConnector::switchScene(const uint8_t scene, const bool discardPrevious)
                 --blockdata.meta.numParametersInScenes;
                 blockdata.meta.enable.hasScenes = false;
                 blockdata.meta.enable.tempSceneState = kTemporarySceneNone;
-                blockdata.scenes.enableValues[previousScene] = blockEnabled;
+                blockdata.scenes.enableValues[previousScene] = blockdata.scenes.lastSavedEnableValues[previousScene];
                 break;
             case kTemporarySceneClear:
                 assert(!blockdata.meta.enable.hasScenes);
                 ++blockdata.meta.numParametersInScenes;
                 blockdata.meta.enable.hasScenes = true;
                 blockdata.meta.enable.tempSceneState = kTemporarySceneNone;
-                blockdata.scenes.enableValues[previousScene] = blockEnabled;
+                blockdata.scenes.enableValues[previousScene] = blockdata.scenes.lastSavedEnableValues[previousScene];
                 break;
             }
 
@@ -2710,19 +2697,6 @@ bool HostConnector::switchScene(const uint8_t scene, const bool discardPrevious)
                 if ((paramdata.meta.flags & Lv2ParameterNotAllowedInScenes) != 0)
                     continue;
 
-                switch (previousSceneState)
-                {
-                case kSceneUnused:
-                    paramValue = paramdata.value;
-                    break;
-                case kSceneInUse:
-                    paramValue = paramdata.scenes.values[previousScene];
-                    break;
-                case kSceneInUseTemporarily:
-                    paramValue = paramdata.scenes.lastSavedValues[previousScene];
-                    break;
-                }
-
                 // revert temp scene state
                 switch (paramdata.meta.tempSceneState)
                 {
@@ -2733,16 +2707,18 @@ bool HostConnector::switchScene(const uint8_t scene, const bool discardPrevious)
                     --blockdata.meta.numParametersInScenes;
                     paramdata.meta.flags &= ~Lv2ParameterInScene;
                     paramdata.meta.tempSceneState = kTemporarySceneNone;
-                    paramdata.scenes.values[previousScene] = paramValue;
+                    paramdata.scenes.values[previousScene] = paramdata.scenes.lastSavedValues[previousScene];
                     break;
                 case kTemporarySceneClear:
                     assert((paramdata.meta.flags & Lv2ParameterInScene) == 0);
                     ++blockdata.meta.numParametersInScenes;
                     paramdata.meta.flags |= Lv2ParameterInScene;
                     paramdata.meta.tempSceneState = kTemporarySceneNone;
-                    paramdata.scenes.values[previousScene] = paramValue;
+                    paramdata.scenes.values[previousScene] = paramdata.scenes.lastSavedValues[previousScene];
                     break;
                 }
+
+                paramValue = activateNewScene ? paramdata.value : paramdata.scenes.values[scene];
 
                 if (isNotEqual(paramdata.value, paramValue))
                 {
@@ -3602,6 +3578,7 @@ void HostConnector::setBlockParameter(const uint8_t row,
             // set new value for current scene
             paramdata.scenes.values[_current.scene] = value;
             paramdata.scenes.lastSavedValues[_current.scene] = value;
+            assert(paramdata.meta.tempSceneState == kTemporarySceneNone);
             break;
 
         case kSceneModeActivateTemporarily:
@@ -3635,6 +3612,7 @@ void HostConnector::setBlockParameter(const uint8_t row,
             }
             paramdata.scenes.values.fill(value);
             paramdata.scenes.lastSavedValues.fill(value);
+            assert(paramdata.meta.tempSceneState == kTemporarySceneNone);
             break;
 
         case kSceneModeClearTemporarily:
@@ -3662,6 +3640,7 @@ void HostConnector::setBlockParameter(const uint8_t row,
                 paramdata.scenes.values[_current.scene] = value;
                 paramdata.scenes.lastSavedValues[_current.scene] = value;
             }
+            assert(paramdata.meta.tempSceneState == kTemporarySceneNone);
             break;
 
         case kSceneModeUpdateTemporarily:
@@ -3672,12 +3651,8 @@ void HostConnector::setBlockParameter(const uint8_t row,
             break;
         }
 
-        if (_current.scenes[_current.scene].state == kSceneInUseTemporarily &&
-            (paramdata.meta.flags & Lv2ParameterInScene) != 0 &&
-            paramdata.meta.tempSceneState == kTemporarySceneNone)
-        {
+        if ((paramdata.meta.flags & Lv2ParameterInScene) != 0 && paramdata.meta.tempSceneState == kTemporarySceneNone)
             _current.scenes[_current.scene].state = kSceneInUse;
-        }
 
         if (paramdata.meta.hwbinding != UINT8_MAX)
         {

--- a/src/connector.cpp
+++ b/src/connector.cpp
@@ -2866,7 +2866,7 @@ bool HostConnector::renameScene(const uint8_t scene, const char* const name)
         _current.scenes[scene].state = HostConnector::kSceneInUse;
 
         if (_current.scenes[_current.scene].state != HostConnector::kSceneUnused)
-            copySceneData(_current.scene, scene);
+            copySceneData(_current.defaultScene, scene);
     }
 
     _current.dirty = true;

--- a/src/connector.cpp
+++ b/src/connector.cpp
@@ -2737,9 +2737,9 @@ bool HostConnector::switchScene(const uint8_t scene, const bool switchEvenIfSame
                 break;
             }
 
-            blockEnabled = activateNewScene || !blockdata.meta.enable.hasScenes
-                         ? blockdata.scenes.lastSavedEnableValues[_current.defaultScene]
-                         : blockdata.scenes.enableValues[scene];
+            blockEnabled = activateNewScene ? blockdata.scenes.lastSavedEnableValues[_current.defaultScene]
+                         : blockdata.meta.enable.hasScenes ? blockdata.scenes.enableValues[scene]
+                         : blockdata.enabled;
 
             // bypass/disable first if relevant
             if (blockdata.enabled != blockEnabled && !blockEnabled)
@@ -2776,9 +2776,9 @@ bool HostConnector::switchScene(const uint8_t scene, const bool switchEvenIfSame
                     break;
                 }
 
-                paramValue = activateNewScene || (paramdata.meta.flags & Lv2ParameterInScene) == 0
-                           ? paramdata.scenes.lastSavedValues[_current.defaultScene]
-                           : paramdata.scenes.values[scene];
+                paramValue = activateNewScene ? paramdata.scenes.lastSavedValues[_current.defaultScene]
+                           : (paramdata.meta.flags & Lv2ParameterInScene) != 0 ? paramdata.scenes.values[scene]
+                           : paramdata.value;
 
                 if (isNotEqual(paramdata.value, paramValue))
                 {

--- a/src/connector.cpp
+++ b/src/connector.cpp
@@ -2430,7 +2430,12 @@ void HostConnector::clearAllScenes()
         modified = true;
     }
 
-    _current.defaultScene = 0;
+    if (_current.defaultScene != 0)
+    {
+        _current.defaultScene = 0;
+        modified = true;
+    }
+
     _current.scenes[0].state = HostConnector::kSceneInUse;
 
     if (modified)

--- a/src/connector.cpp
+++ b/src/connector.cpp
@@ -2705,8 +2705,6 @@ bool HostConnector::switchScene(const uint8_t scene, const bool switchEvenIfSame
 
             params.clear();
 
-            blockEnabled = activateNewScene ? blockdata.enabled : blockdata.scenes.enableValues[scene];
-
             // revert temp scene state
             switch (blockdata.meta.enable.tempSceneState)
             {
@@ -2727,6 +2725,10 @@ bool HostConnector::switchScene(const uint8_t scene, const bool switchEvenIfSame
                 blockdata.scenes.enableValues[previousScene] = blockdata.scenes.lastSavedEnableValues[previousScene];
                 break;
             }
+
+            blockEnabled = activateNewScene || !blockdata.meta.enable.hasScenes
+                         ? blockdata.enabled
+                         : blockdata.scenes.enableValues[scene];
 
             // bypass/disable first if relevant
             if (blockdata.enabled != blockEnabled && !blockEnabled)
@@ -2763,7 +2765,9 @@ bool HostConnector::switchScene(const uint8_t scene, const bool switchEvenIfSame
                     break;
                 }
 
-                paramValue = activateNewScene ? paramdata.value : paramdata.scenes.values[scene];
+                paramValue = activateNewScene || (paramdata.meta.flags & Lv2ParameterInScene) == 0
+                           ? paramdata.value
+                           : paramdata.scenes.values[scene];
 
                 if (isNotEqual(paramdata.value, paramValue))
                 {

--- a/src/connector.cpp
+++ b/src/connector.cpp
@@ -2546,6 +2546,17 @@ bool HostConnector::reorderScenes(const uint8_t orig, const uint8_t dest)
 
                 vector_bool_swap(blockdata.scenes.enableValues, sceneA, sceneB);
                 vector_bool_swap(blockdata.scenes.lastSavedEnableValues, sceneA, sceneB);
+
+                for (Parameter& paramdata : blockdata.parameters)
+                {
+                    if (isNullURI(paramdata.symbol))
+                        break;
+                    if ((paramdata.meta.flags & Lv2ParameterNotAllowedInScenes) != 0)
+                        continue;
+
+                    std::swap(paramdata.scenes.values[sceneA], paramdata.scenes.values[sceneB]);
+                    std::swap(paramdata.scenes.lastSavedValues[sceneA], paramdata.scenes.lastSavedValues[sceneB]);
+                }
             }
         }
 
@@ -2624,6 +2635,17 @@ void HostConnector::swapScenes(const uint8_t sceneA, const uint8_t sceneB)
 
             vector_bool_swap(blockdata.scenes.enableValues, sceneA, sceneB);
             vector_bool_swap(blockdata.scenes.lastSavedEnableValues, sceneA, sceneB);
+
+            for (Parameter& paramdata : blockdata.parameters)
+            {
+                if (isNullURI(paramdata.symbol))
+                    break;
+                if ((paramdata.meta.flags & Lv2ParameterNotAllowedInScenes) != 0)
+                    continue;
+
+                std::swap(paramdata.scenes.values[sceneA], paramdata.scenes.values[sceneB]);
+                std::swap(paramdata.scenes.lastSavedValues[sceneA], paramdata.scenes.lastSavedValues[sceneB]);
+            }
         }
     }
 

--- a/src/connector.cpp
+++ b/src/connector.cpp
@@ -5706,6 +5706,7 @@ void HostConnector::jsonPresetLoad(Preset& presetdata, const nlohmann::json& jpr
                 }
 
                 presetdata.scenes[s].name = name;
+                presetdata.scenes[s].state = HostConnector::kSceneInUse;
             }
             else
             {
@@ -5717,6 +5718,10 @@ void HostConnector::jsonPresetLoad(Preset& presetdata, const nlohmann::json& jpr
     {
         for (Scene& scenedata : presetdata.scenes)
             scenedata.name.clear();
+
+        // scene names not included, typically means no scenes present
+        // make sure to activate the first scene as to match new-preset behaviour
+        presetdata.scenes[0].state = HostConnector::kSceneInUse;
     }
 
     // ----------------------------------------------------------------------------------------------------------------

--- a/src/connector.cpp
+++ b/src/connector.cpp
@@ -1081,6 +1081,12 @@ bool HostConnector::saveCurrentPresetToFile(const char* const filename)
                 }
             }
         }
+
+        for (uint8_t s = 0; s < NUM_SCENES_PER_PRESET; ++s)
+        {
+            if (_current.scenes[s].state == kSceneInUseTemporarily)
+                _current.scenes[s].state = kSceneInUse;
+        }
     }
 
     // copy current data into preset data
@@ -1389,8 +1395,8 @@ bool HostConnector::enableBlock(const uint8_t row, const uint8_t block, const bo
                 --blockdata.meta.numParametersInScenes;
                 blockdata.meta.enable.hasScenes = false;
             }
-            blockdata.scenes.enableValues.fill(enable);
-            blockdata.scenes.lastSavedEnableValues.fill(enable);
+            // blockdata.scenes.enableValues.fill(enable);
+            // blockdata.scenes.lastSavedEnableValues.fill(enable);
             assert(blockdata.meta.enable.tempSceneState == kTemporarySceneNone);
             break;
 
@@ -1405,16 +1411,16 @@ bool HostConnector::enableBlock(const uint8_t row, const uint8_t block, const bo
                                                     ? kTemporarySceneClear
                                                     : kTemporarySceneNone;
             }
-            blockdata.scenes.enableValues.fill(enable);
+            // blockdata.scenes.enableValues.fill(enable);
             break;
 
         case kSceneModeUpdate:
-            if (! blockdata.meta.enable.hasScenes)
-            {
-                blockdata.scenes.enableValues.fill(enable);
-                blockdata.scenes.lastSavedEnableValues.fill(enable);
-            }
-            else
+            if (blockdata.meta.enable.hasScenes)
+            // {
+            //     blockdata.scenes.enableValues.fill(enable);
+            //     blockdata.scenes.lastSavedEnableValues.fill(enable);
+            // }
+            // else
             {
                 blockdata.scenes.enableValues[_current.scene] = enable;
                 blockdata.scenes.lastSavedEnableValues[_current.scene] = enable;
@@ -1423,9 +1429,9 @@ bool HostConnector::enableBlock(const uint8_t row, const uint8_t block, const bo
             break;
 
         case kSceneModeUpdateTemporarily:
-            if (! blockdata.meta.enable.hasScenes)
-                blockdata.scenes.enableValues.fill(enable);
-            else
+            if (blockdata.meta.enable.hasScenes)
+            //     blockdata.scenes.enableValues.fill(enable);
+            // else
                 blockdata.scenes.enableValues[_current.scene] = enable;
             break;
         }
@@ -2438,6 +2444,9 @@ void HostConnector::clearAllScenes()
 
                 paramdata.meta.flags &= ~Lv2ParameterInScene;
                 paramdata.meta.tempSceneState = kTemporarySceneNone;
+
+                // paramdata.scenes.values.fill(paramdata.value);
+                // paramdata.scenes.lastSavedValues.fill(paramdata.value);
             }
         }
     }
@@ -2766,7 +2775,7 @@ bool HostConnector::switchScene(const uint8_t scene, const bool discardPrevious)
             }
 
             if (activateNewScene)
-                blockdata.scenes.enableValues[scene] = blockdata.scenes.enableValues[scene] = blockEnabled;
+                blockdata.scenes.enableValues[scene] = blockdata.scenes.lastSavedEnableValues[scene] = blockEnabled;
         }
     }
 
@@ -3636,8 +3645,8 @@ void HostConnector::setBlockParameter(const uint8_t row,
                 --blockdata.meta.numParametersInScenes;
                 paramdata.meta.flags &= ~Lv2ParameterInScene;
             }
-            paramdata.scenes.values.fill(value);
-            paramdata.scenes.lastSavedValues.fill(value);
+            // paramdata.scenes.values.fill(value);
+            // paramdata.scenes.lastSavedValues.fill(value);
             assert(paramdata.meta.tempSceneState == kTemporarySceneNone);
             break;
 
@@ -3652,16 +3661,16 @@ void HostConnector::setBlockParameter(const uint8_t row,
                                               ? kTemporarySceneClear
                                               : kTemporarySceneNone;
             }
-            paramdata.scenes.values.fill(value);
+            // paramdata.scenes.values.fill(value);
             break;
 
         case kSceneModeUpdate:
-            if ((paramdata.meta.flags & Lv2ParameterInScene) == 0)
-            {
-                paramdata.scenes.values.fill(value);
-                paramdata.scenes.lastSavedValues.fill(value);
-            }
-            else
+            if ((paramdata.meta.flags & Lv2ParameterInScene) != 0)
+            // {
+            //     paramdata.scenes.values.fill(value);
+            //     paramdata.scenes.lastSavedValues.fill(value);
+            // }
+            // else
             {
                 paramdata.scenes.values[_current.scene] = value;
                 paramdata.scenes.lastSavedValues[_current.scene] = value;
@@ -3670,9 +3679,9 @@ void HostConnector::setBlockParameter(const uint8_t row,
             break;
 
         case kSceneModeUpdateTemporarily:
-            if ((paramdata.meta.flags & Lv2ParameterInScene) == 0)
-                paramdata.scenes.values.fill(value);
-            else
+            if ((paramdata.meta.flags & Lv2ParameterInScene) != 0)
+            //     paramdata.scenes.values.fill(value);
+            // else
                 paramdata.scenes.values[_current.scene] = value;
             break;
         }
@@ -5790,6 +5799,9 @@ void HostConnector::jsonPresetSave(const Preset& presetdata, nlohmann::json& jpr
                 if (isNullBlock(blockdata))
                     continue;
 
+                // save operation must have converted these already
+                assert(blockdata.meta.enable.tempSceneState == kTemporarySceneNone);
+
                 const std::string jblockid = std::to_string(bl + 1);
                 auto& jblock = jblocks[jblockid] = nlohmann::json::object({
                     { "parameters", nlohmann::json::object({}) },
@@ -5812,6 +5824,9 @@ void HostConnector::jsonPresetSave(const Preset& presetdata, nlohmann::json& jpr
                             break;
                         if (! shouldSaveParameterToPreset(paramdata.meta.flags))
                             continue;
+
+                        // save operation must have converted these already
+                        assert(paramdata.meta.tempSceneState == kTemporarySceneNone);
 
                         const std::string jparamid = std::to_string(++jp);
                         jparams[jparamid] = nlohmann::json::object({
@@ -5843,12 +5858,18 @@ void HostConnector::jsonPresetSave(const Preset& presetdata, nlohmann::json& jpr
                     }
                 }
 
-                if (blockdata.meta.numParametersInScenes != 0)
+                if (hasScenes(blockdata))
                 {
                     auto& jscenes = jblock["scenes"];
 
                     for (uint8_t s = 0; s < NUM_SCENES_PER_PRESET; ++s)
                     {
+                        // save operation must have converted these already
+                        assert(presetdata.scenes[s].state != kSceneInUseTemporarily);
+
+                        if (presetdata.scenes[s].state == kSceneUnused)
+                            continue;
+
                         const std::string jsceneid = std::to_string(s + 1);
                         auto& jscene = jscenes[jsceneid] = nlohmann::json::object({
                             { "parameters", nlohmann::json::array() },
@@ -7145,8 +7166,8 @@ void HostConnector::setEnableChangesNotSavedToPreset(Block& blockdata, const boo
         --blockdata.meta.numParametersInScenes;
         blockdata.meta.enable.hasScenes = false;
     }
-    blockdata.scenes.enableValues.fill(blockdata.enabled);
-    blockdata.scenes.lastSavedEnableValues.fill(blockdata.enabled);
+    // blockdata.scenes.enableValues.fill(blockdata.enabled);
+    // blockdata.scenes.lastSavedEnableValues.fill(blockdata.enabled);
 }
 
 void HostConnector::setParamChangesNotSavedToPreset(Block& blockdata,
@@ -7169,8 +7190,8 @@ void HostConnector::setParamChangesNotSavedToPreset(Block& blockdata,
         --blockdata.meta.numParametersInScenes;
         paramdata.meta.flags &= ~Lv2ParameterInScene;
     }
-    paramdata.scenes.values.fill(paramdata.value);
-    paramdata.scenes.lastSavedValues.fill(paramdata.value);
+    // paramdata.scenes.values.fill(paramdata.value);
+    // paramdata.scenes.lastSavedValues.fill(paramdata.value);
 }
 
 // --------------------------------------------------------------------------------------------------------------------

--- a/src/connector.cpp
+++ b/src/connector.cpp
@@ -2485,13 +2485,13 @@ void HostConnector::clearScene(const uint8_t scene)
 
 bool HostConnector::copyScene(const uint8_t orig, const uint8_t dest)
 {
-    mod_log_debug("reorderScenes(%u, %u)", orig, dest);
+    mod_log_debug("copyScene(%u, %u)", orig, dest);
     assert(orig < NUM_SCENES_PER_PRESET);
     assert(dest < NUM_SCENES_PER_PRESET);
 
     if (orig == dest)
     {
-        mod_log_warn("reorderScenes(%u, %u) - orig == dest, rejected", orig, dest);
+        mod_log_warn("copyScene(%u, %u) - orig == dest, rejected", orig, dest);
         return false;
     }
 

--- a/src/connector.cpp
+++ b/src/connector.cpp
@@ -5941,18 +5941,17 @@ void HostConnector::jsonPresetSave(const Preset& presetdata, nlohmann::json& jpr
 
     if (std::any_of(presetdata.scenes.cbegin(),
                     presetdata.scenes.cend(),
-                    [](const Scene& scenedata){ return !scenedata.name.empty(); }))
+                    [](const Scene& scenedata){ return scenedata.state != kSceneUnused; }))
     {
         auto& jsceneNames = jpreset["sceneNames"] = nlohmann::json::object({});
 
-        std::string name;
         std::string jsceneid;
         for (uint8_t s = 0; s < NUM_SCENES_PER_PRESET; ++s)
         {
-            if (name = presetdata.scenes[s].name; !name.empty())
+            if (presetdata.scenes[s].state != kSceneUnused)
             {
                 jsceneid = std::to_string(s + 1);
-                jsceneNames[jsceneid] = name;
+                jsceneNames[jsceneid] = presetdata.scenes[s].name;
             }
         }
     }

--- a/src/connector.cpp
+++ b/src/connector.cpp
@@ -5193,6 +5193,7 @@ void HostConnector::jsonPresetLoad(Preset& presetdata, const nlohmann::json& jpr
                                 }
 
                                 blockdata.scenes.enableValues[s] = enabled;
+                                presetdata.scenes[s].active = true;
                             }
                         }
 
@@ -5257,6 +5258,7 @@ void HostConnector::jsonPresetLoad(Preset& presetdata, const nlohmann::json& jpr
                                     paramdata.scenes.values[s] = std::clamp<float>(value,
                                                                                    paramdata.meta.min,
                                                                                    paramdata.meta.max);
+                                    presetdata.scenes[s].active = true;
                                 }
                             }
                         }
@@ -5597,38 +5599,38 @@ void HostConnector::jsonPresetLoad(Preset& presetdata, const nlohmann::json& jpr
     // ----------------------------------------------------------------------------------------------------------------
     // sceneNames
 
-    // TODO
-    // if (jpreset.contains("sceneNames"))
-    // {
-    //     const auto& jsceneNames = jpreset["sceneNames"];
-    //     std::string name;
-    //
-    //     for (uint8_t s = 0; s < NUM_SCENES_PER_PRESET; ++s)
-    //     {
-    //         const std::string jsceneid = std::to_string(s + 1);
-    //
-    //         if (jsceneNames.contains(jsceneid))
-    //         {
-    //             try {
-    //                 name = jsceneNames[jsceneid].get<std::string>();
-    //             } catch (...) {
-    //                 mod_log_warn("jsonPresetLoad(): preset contains invalid scene name");
-    //                 name.clear();
-    //             }
-    //
-    //             presetdata.sceneNames[s] = name;
-    //         }
-    //         else
-    //         {
-    //             presetdata.sceneNames[s].clear();
-    //         }
-    //     }
-    // }
-    // else
-    // {
-    //     for (uint8_t s = 0; s < NUM_SCENES_PER_PRESET; ++s)
-    //         presetdata.sceneNames[s].clear();
-    // }
+    if (jpreset.contains("sceneNames"))
+    {
+        const auto& jsceneNames = jpreset["sceneNames"];
+        std::string jsceneid;
+        std::string name;
+
+        for (uint8_t s = 0; s < NUM_SCENES_PER_PRESET; ++s)
+        {
+            jsceneid = std::to_string(s + 1);
+
+            if (jsceneNames.contains(jsceneid))
+            {
+                try {
+                    name = jsceneNames[jsceneid].get<std::string>();
+                } catch (...) {
+                    mod_log_warn("jsonPresetLoad(): preset contains invalid scene name");
+                    name.clear();
+                }
+
+                presetdata.scenes[s].name = name;
+            }
+            else
+            {
+                presetdata.scenes[s].name.clear();
+            }
+        }
+    }
+    else
+    {
+        for (Scene& scenedata : presetdata.scenes)
+            scenedata.name.clear();
+    }
 
     // ----------------------------------------------------------------------------------------------------------------
     // uuid
@@ -5838,20 +5840,23 @@ void HostConnector::jsonPresetSave(const Preset& presetdata, nlohmann::json& jpr
     // ----------------------------------------------------------------------------------------------------------------
     // sceneNames
 
-    // TODO
-    // for (const std::string& sceneName : presetdata.sceneNames)
-    // {
-    //     if (sceneName.empty())
-    //         continue;
-    //
-    //     auto& jsceneNames = jpreset["sceneNames"] = nlohmann::json::object({});
-    //     for (uint8_t s = 0; s < NUM_SCENES_PER_PRESET; ++s)
-    //     {
-    //         const std::string jsceneid = std::to_string(s + 1);
-    //         jsceneNames[jsceneid] = presetdata.sceneNames[s];
-    //     }
-    //     break;
-    // }
+    if (std::any_of(presetdata.scenes.cbegin(),
+                    presetdata.scenes.cend(),
+                    [](const Scene& scenedata){ return !scenedata.name.empty(); }))
+    {
+        auto& jsceneNames = jpreset["sceneNames"] = nlohmann::json::object({});
+
+        std::string name;
+        std::string jsceneid;
+        for (uint8_t s = 0; s < NUM_SCENES_PER_PRESET; ++s)
+        {
+            if (name = presetdata.scenes[s].name; !name.empty())
+            {
+                jsceneid = std::to_string(s + 1);
+                jsceneNames[jsceneid] = name;
+            }
+        }
+    }
 }
 
 // --------------------------------------------------------------------------------------------------------------------

--- a/src/connector.cpp
+++ b/src/connector.cpp
@@ -2430,6 +2430,9 @@ void HostConnector::clearAllScenes()
         modified = true;
     }
 
+    _current.defaultScene = 0;
+    _current.scenes[0].state = HostConnector::kSceneInUse;
+
     if (modified)
         _current.dirty = true;
 
@@ -4999,6 +5002,15 @@ void HostConnector::hostRemoveInstanceForBlock(const uint8_t row, const uint8_t 
 
 void HostConnector::jsonPresetLoad(Preset& presetdata, const nlohmann::json& jpreset) const
 {
+    // ----------------------------------------------------------------------------------------------------------------
+    // always do cleanup before anything else, for optional values that might not get set
+
+    for (uint8_t s = 0; s < NUM_SCENES_PER_PRESET; ++s)
+    {
+        presetdata.scenes[s].state = HostConnector::kSceneUnused;
+        presetdata.scenes[s].name.clear();
+    }
+
     // ----------------------------------------------------------------------------------------------------------------
     // background
 

--- a/src/connector.cpp
+++ b/src/connector.cpp
@@ -2423,8 +2423,6 @@ void HostConnector::clearAllScenes()
 
     for (uint8_t s = 0; s < NUM_SCENES_PER_PRESET; ++s)
     {
-        if (_current.scenes[s].state == HostConnector::kSceneUnused)
-            continue;
         _current.scenes[s].state = HostConnector::kSceneUnused;
         _current.scenes[s].name.clear();
         modified = true;
@@ -2433,6 +2431,12 @@ void HostConnector::clearAllScenes()
     if (_current.defaultScene != 0)
     {
         _current.defaultScene = 0;
+        modified = true;
+    }
+
+    if (_current.scene != 0)
+    {
+        _current.scene = 0;
         modified = true;
     }
 

--- a/src/connector.cpp
+++ b/src/connector.cpp
@@ -2497,6 +2497,9 @@ bool HostConnector::copyScene(const uint8_t orig, const uint8_t dest)
         _current.scenes[dest].name = _current.scenes[orig].name;
         _current.scenes[dest].state = HostConnector::kSceneInUse;
         copySceneData(orig, dest);
+
+        if (_current.scene == dest)
+            switchScene(dest, true);
     }
     else
     {
@@ -2644,14 +2647,12 @@ void HostConnector::swapScenes(const uint8_t sceneA, const uint8_t sceneB)
 
 // --------------------------------------------------------------------------------------------------------------------
 
-bool HostConnector::switchScene(const uint8_t scene, const bool discardPrevious)
+bool HostConnector::switchScene(const uint8_t scene, const bool switchEvenIfSameScene)
 {
-    mod_log_debug("switchScene(%u, %s)", scene, bool2str(discardPrevious));
+    mod_log_debug("switchScene(%u, %s)", scene, bool2str(switchEvenIfSameScene));
     assert(scene < NUM_SCENES_PER_PRESET);
 
-    // TODO discardPrevious
-
-    if (_current.scene == scene)
+    if (_current.scene == scene && ! switchEvenIfSameScene)
         return false;
 
     // preallocating some data
@@ -2671,12 +2672,11 @@ bool HostConnector::switchScene(const uint8_t scene, const bool discardPrevious)
             _current.dirty = false;
     }
 
+    const bool activateNewScene = _current.scenes[scene].state == kSceneUnused;
     const uint8_t previousScene = _current.scene;
 
     if (_current.scenes[previousScene].state == kSceneInUseTemporarily)
         _current.scenes[previousScene].state = kSceneUnused;
-
-    const bool activateNewScene = _current.scenes[scene].state == kSceneUnused;
 
     _current.scene = scene;
 

--- a/src/connector.cpp
+++ b/src/connector.cpp
@@ -1247,6 +1247,8 @@ void HostConnector::clearCurrentPreset()
 {
     mod_log_debug("clearCurrentPreset()");
 
+    clearAllSceneData();
+
     _current.uuid = generateUUID();
 
     if (_current.numLoadedPlugins == 0)
@@ -1272,7 +1274,6 @@ void HostConnector::clearCurrentPreset()
         _current.bindings[hwid].parameters.clear();
     }
 
-    _current.scene = _current.defaultScene = 0;
     _current.numLoadedPlugins = 0;
     _current.dirty = true;
 
@@ -2419,31 +2420,7 @@ void HostConnector::clearAllScenes()
 {
     mod_log_debug("clearAllScenes()");
 
-    bool modified = false;
-
-    for (uint8_t s = 0; s < NUM_SCENES_PER_PRESET; ++s)
-    {
-        _current.scenes[s].state = HostConnector::kSceneUnused;
-        _current.scenes[s].name.clear();
-        modified = true;
-    }
-
-    if (_current.defaultScene != 0)
-    {
-        _current.defaultScene = 0;
-        modified = true;
-    }
-
-    if (_current.scene != 0)
-    {
-        _current.scene = 0;
-        modified = true;
-    }
-
-    _current.scenes[0].state = HostConnector::kSceneInUse;
-
-    if (modified)
-        _current.dirty = true;
+    clearAllSceneData();
 
     for (uint8_t row = 0; row < NUM_BLOCK_CHAIN_ROWS; ++row)
     {
@@ -6843,6 +6820,39 @@ void HostConnector::enableAudioProcessing(const bool enable)
 void HostConnector::setDirty(const bool dirty)
 {
     _current.dirty = dirty;
+}
+
+// --------------------------------------------------------------------------------------------------------------------
+
+void HostConnector::clearAllSceneData()
+{
+    bool modified = false;
+
+    for (uint8_t s = 0; s < NUM_SCENES_PER_PRESET; ++s)
+    {
+        if (_current.scenes[s].state == HostConnector::kSceneUnused)
+            continue;
+        _current.scenes[s].state = HostConnector::kSceneUnused;
+        _current.scenes[s].name.clear();
+        modified = true;
+    }
+
+    if (_current.defaultScene != 0)
+    {
+        _current.defaultScene = 0;
+        modified = true;
+    }
+
+    if (_current.scene != 0)
+    {
+        _current.scene = 0;
+        modified = true;
+    }
+
+    _current.scenes[0].state = HostConnector::kSceneInUse;
+
+    if (modified)
+        _current.dirty = true;
 }
 
 // --------------------------------------------------------------------------------------------------------------------

--- a/src/connector.cpp
+++ b/src/connector.cpp
@@ -1448,7 +1448,7 @@ bool HostConnector::enableBlock(const uint8_t row, const uint8_t block, const bo
         ParameterBinding& binding = bindings.parameters.front();
 
         if (bindings.parameters.size() == 1 &&
-            (binding.row == row && binding.block == block && binding.parameterSymbol == ":bypass"))
+            (binding.row == row && binding.block == block && binding.meta.isBypass))
         {
             bindings.value = enable ? binding.max : binding.min;
         }
@@ -2830,7 +2830,7 @@ bool HostConnector::switchScene(const uint8_t scene, const bool switchEvenIfSame
 
         for (const ParameterBinding& binding : bindings.parameters)
         {
-            if (binding.parameterSymbol == ":bypass")
+            if (binding.meta.isBypass)
                 continue;
 
             assert(binding.meta.parameterIndex < NUM_BLOCKS_PER_PRESET);
@@ -2854,7 +2854,7 @@ bool HostConnector::switchScene(const uint8_t scene, const bool switchEvenIfSame
             const ParameterBinding& binding = bindings.parameters.front();
             const Block& blockdata = _current.chains[binding.row].blocks[binding.block];
 
-            if (binding.parameterSymbol == ":bypass")
+            if (binding.meta.isBypass)
             {
                 bindings.value = blockdata.enabled ? binding.max : binding.min;
             }
@@ -3033,7 +3033,7 @@ bool HostConnector::editBlockBinding(const uint8_t hwid, const uint8_t row, cons
             continue;
         if (it->block != block)
             continue;
-        if (it->parameterSymbol != ":bypass")
+        if (! it->meta.isBypass)
             continue;
 
         it->min = inverted ? 1.f : 0.f;
@@ -3076,7 +3076,7 @@ bool HostConnector::editBlockParameterBinding(const uint8_t hwid,
             continue;
         if (it->block != block)
             continue;
-        if (it->parameterSymbol == ":bypass")
+        if (it->meta.isBypass)
             continue;
         if (it->meta.parameterIndex != paramIndex)
             continue;
@@ -3159,7 +3159,7 @@ bool HostConnector::removeBlockBinding(const uint8_t hwid, const uint8_t row, co
             continue;
         if (it->block != block)
             continue;
-        if (it->parameterSymbol != ":bypass")
+        if (! it->meta.isBypass)
             continue;
 
         bindings.erase(it);
@@ -3206,7 +3206,7 @@ bool HostConnector::removeBlockParameterBinding(const uint8_t hwid,
             continue;
         if (it->block != block)
             continue;
-        if (it->parameterSymbol == ":bypass")
+        if (it->meta.isBypass)
             continue;
         if (it->meta.parameterIndex != paramIndex)
             continue;
@@ -3272,7 +3272,7 @@ bool HostConnector::replaceBlockBinding(const uint8_t hwid,
             continue;
         if (it->block != block)
             continue;
-        if (it->parameterSymbol != ":bypass")
+        if (! it->meta.isBypass)
             continue;
 
         const float min = it->min;
@@ -3521,7 +3521,7 @@ void HostConnector::setBindingValue(const uint8_t hwid,
             float min = it->min;
             float max = it->max;
 
-            if (it->parameterSymbol == ":bypass")
+            if (it->meta.isBypass)
             {
                 const bool enabled = min > max ? value < 0.5 : value >= 0.5;
                 enableBlock(row, block, enabled, sceneMode);

--- a/src/connector.cpp
+++ b/src/connector.cpp
@@ -2710,6 +2710,8 @@ bool HostConnector::switchScene(const uint8_t scene, const bool switchEvenIfSame
             switch (blockdata.meta.enable.tempSceneState)
             {
             case kTemporarySceneNone:
+                if (discardIfUnused)
+                    blockdata.scenes.enableValues[previousScene] = blockdata.scenes.lastSavedEnableValues[previousScene];
                 break;
             case kTemporarySceneActivate:
                 assert(blockdata.meta.enable.hasScenes);
@@ -2749,6 +2751,8 @@ bool HostConnector::switchScene(const uint8_t scene, const bool switchEvenIfSame
                 switch (paramdata.meta.tempSceneState)
                 {
                 case kTemporarySceneNone:
+                    if (discardIfUnused)
+                        paramdata.scenes.values[previousScene] = paramdata.scenes.lastSavedValues[previousScene];
                     break;
                 case kTemporarySceneActivate:
                     assert((paramdata.meta.flags & Lv2ParameterInScene) != 0);

--- a/src/connector.cpp
+++ b/src/connector.cpp
@@ -2369,6 +2369,8 @@ void HostConnector::renamePreset(const uint8_t preset, const char* const name)
 
 void HostConnector::clearAllScenes()
 {
+    mod_log_debug("clearAllScenes()");
+
     bool modified = false;
 
     for (uint8_t s = 0; s < NUM_SCENES_PER_PRESET; ++s)
@@ -2440,45 +2442,9 @@ bool HostConnector::copyScene(const uint8_t orig, const uint8_t dest)
     }
 
     if (_current.scenes[orig].active)
-    {
-        _current.scenes[dest].active = true;
-        _current.scenes[dest].name = _current.scenes[orig].name;
-
-        for (uint8_t row = 0; row < NUM_BLOCK_CHAIN_ROWS; ++row)
-        {
-            for (uint8_t bl = 0; bl < NUM_BLOCKS_PER_PRESET; ++bl)
-            {
-                Block& blockdata(_current.chains[row].blocks[bl]);
-                if (isNullBlock(blockdata))
-                    continue;
-                if (blockdata.meta.numParametersInScenes == 0)
-                    continue;
-
-                if (blockdata.meta.enable.hasScenes)
-                {
-                    blockdata.scenes.enableValues[dest] = blockdata.scenes.enableValues[orig];
-                    blockdata.scenes.lastSavedEnableValues[dest] = blockdata.scenes.enableValues[orig];
-                }
-
-                for (Parameter& paramdata : blockdata.parameters)
-                {
-                    if (isNullURI(paramdata.symbol))
-                        break;
-                    if ((paramdata.meta.flags & Lv2ParameterNotAllowedToChange) != 0)
-                        continue;
-                    if ((paramdata.meta.flags & Lv2ParameterInScene) == 0)
-                        continue;
-
-                    paramdata.scenes.values[dest] = paramdata.scenes.values[orig];
-                    paramdata.scenes.lastSavedValues[dest] = paramdata.scenes.values[orig];
-                }
-            }
-        }
-    }
+        copySceneData(orig, dest);
     else
-    {
         clearScene(dest);
-    }
 
     _current.dirty = true;
     return true;
@@ -2832,8 +2798,15 @@ bool HostConnector::renameScene(const uint8_t scene, const char* const name)
     if (_current.scenes[scene].name == name)
         return false;
 
+    if (! _current.scenes[scene].active)
+    {
+        if (_current.scenes[_current.scene].active)
+            copySceneData(_current.scene, scene);
+        else
+            _current.scenes[scene].active = true;
+    }
+
     _current.dirty = true;
-    _current.scenes[scene].active = true;
     _current.scenes[scene].name = name;
     return true;
 }
@@ -6731,6 +6704,47 @@ void HostConnector::setDirty(const bool dirty)
 }
 
 // --------------------------------------------------------------------------------------------------------------------
+
+void HostConnector::copySceneData(uint8_t orig, uint8_t dest)
+{
+    assert(orig < NUM_SCENES_PER_PRESET);
+    assert(dest < NUM_SCENES_PER_PRESET);
+    assert(_current.scenes[orig].active);
+
+    _current.scenes[dest].active = true;
+    _current.scenes[dest].name = _current.scenes[orig].name;
+
+    for (uint8_t row = 0; row < NUM_BLOCK_CHAIN_ROWS; ++row)
+    {
+        for (uint8_t bl = 0; bl < NUM_BLOCKS_PER_PRESET; ++bl)
+        {
+            Block& blockdata(_current.chains[row].blocks[bl]);
+            if (isNullBlock(blockdata))
+                continue;
+            if (blockdata.meta.numParametersInScenes == 0)
+                continue;
+
+            if (blockdata.meta.enable.hasScenes)
+            {
+                blockdata.scenes.enableValues[dest] = blockdata.scenes.enableValues[orig];
+                blockdata.scenes.lastSavedEnableValues[dest] = blockdata.scenes.enableValues[orig];
+            }
+
+            for (Parameter& paramdata : blockdata.parameters)
+            {
+                if (isNullURI(paramdata.symbol))
+                    break;
+                if ((paramdata.meta.flags & Lv2ParameterNotAllowedToChange) != 0)
+                    continue;
+                if ((paramdata.meta.flags & Lv2ParameterInScene) == 0)
+                    continue;
+
+                paramdata.scenes.values[dest] = paramdata.scenes.values[orig];
+                paramdata.scenes.lastSavedValues[dest] = paramdata.scenes.values[orig];
+            }
+        }
+    }
+}
 
 void HostConnector::initBlock(HostConnector::Block& blockdata,
                               const std::shared_ptr<const Lv2Plugin>& plugin,

--- a/src/connector.cpp
+++ b/src/connector.cpp
@@ -2707,7 +2707,7 @@ bool HostConnector::switchScene(const uint8_t scene, const bool switchEvenIfSame
 
     if (activateNewScene)
     {
-        _current.scenes[scene].name = _current.scenes[previousScene].name;
+        _current.scenes[scene].name.clear();
         _current.scenes[scene].state = kSceneInUseTemporarily;
     }
 

--- a/src/connector.cpp
+++ b/src/connector.cpp
@@ -2407,7 +2407,7 @@ void HostConnector::clearAllScenes()
 
     for (uint8_t s = 0; s < NUM_SCENES_PER_PRESET; ++s)
     {
-        if (_current.scenes[s].state != HostConnector::kSceneUnused)
+        if (_current.scenes[s].state == HostConnector::kSceneUnused)
             continue;
         _current.scenes[s].state = HostConnector::kSceneUnused;
         _current.scenes[s].name.clear();

--- a/src/connector.cpp
+++ b/src/connector.cpp
@@ -443,7 +443,7 @@ void HostConnector::Preset::copy(const Preset& other)
     for (uint8_t i = 0; i < NUM_BINDING_ACTUATORS; ++i)
         bindings[i].copy(other.bindings[i]);
     background = other.background;
-    sceneNames = other.sceneNames;
+    scenes = other.scenes;
     uuid = other.uuid;
     chains = other.chains;
 }
@@ -2367,6 +2367,125 @@ void HostConnector::renamePreset(const uint8_t preset, const char* const name)
 
 // --------------------------------------------------------------------------------------------------------------------
 
+void HostConnector::clearAllScenes()
+{
+    bool modified = false;
+
+    for (uint8_t s = 0; s < NUM_SCENES_PER_PRESET; ++s)
+    {
+        if (_current.scenes[s].active)
+            continue;
+        _current.scenes[s].active = false;
+        _current.scenes[s].name.clear();
+        modified = true;
+    }
+
+    if (modified)
+        _current.dirty = true;
+
+    for (uint8_t row = 0; row < NUM_BLOCK_CHAIN_ROWS; ++row)
+    {
+        for (uint8_t bl = 0; bl < NUM_BLOCKS_PER_PRESET; ++bl)
+        {
+            Block& blockdata(_current.chains[row].blocks[bl]);
+            if (isNullBlock(blockdata))
+                continue;
+
+            blockdata.meta.enable.hasScenes = false;
+            blockdata.meta.enable.tempSceneState = kTemporarySceneNone;
+            blockdata.meta.numParametersInScenes = 0;
+
+            for (Parameter& paramdata : blockdata.parameters)
+            {
+                if (isNullURI(paramdata.symbol))
+                    break;
+                if ((paramdata.meta.flags & Lv2ParameterNotAllowedToChange) != 0)
+                    continue;
+
+                paramdata.meta.flags &= ~Lv2ParameterInScene;
+                paramdata.meta.tempSceneState = kTemporarySceneNone;
+            }
+        }
+    }
+}
+
+// --------------------------------------------------------------------------------------------------------------------
+
+void HostConnector::clearScene(const uint8_t scene)
+{
+    mod_log_debug("clearScene(%u)", scene);
+    assert(scene < NUM_SCENES_PER_PRESET);
+
+    if (! _current.scenes[scene].active)
+        return;
+
+    _current.scenes[scene].active = false;
+    _current.scenes[scene].name.clear();
+
+    _current.dirty = true;
+}
+
+// --------------------------------------------------------------------------------------------------------------------
+
+bool HostConnector::copyScene(const uint8_t orig, const uint8_t dest)
+{
+    mod_log_debug("reorderScenes(%u, %u)", orig, dest);
+    assert(orig < NUM_SCENES_PER_PRESET);
+    assert(dest < NUM_SCENES_PER_PRESET);
+
+    if (orig == dest)
+    {
+        mod_log_warn("reorderScenes(%u, %u) - orig == dest, rejected", orig, dest);
+        return false;
+    }
+
+    if (_current.scenes[orig].active)
+    {
+        _current.scenes[dest].active = true;
+        _current.scenes[dest].name = _current.scenes[orig].name;
+
+        for (uint8_t row = 0; row < NUM_BLOCK_CHAIN_ROWS; ++row)
+        {
+            for (uint8_t bl = 0; bl < NUM_BLOCKS_PER_PRESET; ++bl)
+            {
+                Block& blockdata(_current.chains[row].blocks[bl]);
+                if (isNullBlock(blockdata))
+                    continue;
+                if (blockdata.meta.numParametersInScenes == 0)
+                    continue;
+
+                if (blockdata.meta.enable.hasScenes)
+                {
+                    blockdata.scenes.enableValues[dest] = blockdata.scenes.enableValues[orig];
+                    blockdata.scenes.lastSavedEnableValues[dest] = blockdata.scenes.enableValues[orig];
+                }
+
+                for (Parameter& paramdata : blockdata.parameters)
+                {
+                    if (isNullURI(paramdata.symbol))
+                        break;
+                    if ((paramdata.meta.flags & Lv2ParameterNotAllowedToChange) != 0)
+                        continue;
+                    if ((paramdata.meta.flags & Lv2ParameterInScene) == 0)
+                        continue;
+
+                    paramdata.scenes.values[dest] = paramdata.scenes.values[orig];
+                    paramdata.scenes.lastSavedValues[dest] = paramdata.scenes.values[orig];
+                }
+            }
+        }
+    }
+    else
+    {
+        clearScene(dest);
+    }
+
+    _current.dirty = true;
+    return true;
+}
+
+// --------------------------------------------------------------------------------------------------------------------
+
 // std::vector<bool> cannot swap values directly, give it a little hand...
 static void vector_bool_swap(std::vector<bool>& vector, uint8_t a, uint8_t b)
 {
@@ -2404,7 +2523,7 @@ bool HostConnector::reorderScenes(const uint8_t orig, const uint8_t dest)
             }
         }
 
-        std::swap(_current.sceneNames[sceneA], _current.sceneNames[sceneB]);
+        std::swap(_current.scenes[sceneA], _current.scenes[sceneB]);
     };
 
     // moving preset backwards to the left
@@ -2482,7 +2601,7 @@ void HostConnector::swapScenes(const uint8_t sceneA, const uint8_t sceneB)
         }
     }
 
-    std::swap(_current.sceneNames[sceneA], _current.sceneNames[sceneB]);
+    std::swap(_current.scenes[sceneA], _current.scenes[sceneB]);
 
     // adjust data for current scene, if matching
     if (_current.scene == sceneA)
@@ -2502,10 +2621,12 @@ void HostConnector::swapScenes(const uint8_t sceneA, const uint8_t sceneB)
 
 // --------------------------------------------------------------------------------------------------------------------
 
-bool HostConnector::switchScene(const uint8_t scene)
+bool HostConnector::switchScene(const uint8_t scene, const bool discardPrevious)
 {
-    mod_log_debug("switchScene(%u)", scene);
+    mod_log_debug("switchScene(%u, %s)", scene, bool2str(discardPrevious));
     assert(scene < NUM_SCENES_PER_PRESET);
+
+    // TODO discardPrevious
 
     if (_current.scene == scene)
         return false;
@@ -2528,7 +2649,16 @@ bool HostConnector::switchScene(const uint8_t scene)
     }
 
     const uint8_t previousScene = _current.scene;
+    const bool previousSceneWasActive =_current.scenes[previousScene].active;
+    const bool activateNewScene = !_current.scenes[scene].active;
+
     _current.scene = scene;
+
+    if (activateNewScene)
+    {
+        _current.scenes[scene].active = true;
+        _current.scenes[scene].name = _current.scenes[previousScene].name;
+    }
 
     const Host::NonBlockingScope hnbs(_host);
 
@@ -2546,7 +2676,9 @@ bool HostConnector::switchScene(const uint8_t scene)
 
             params.clear();
 
-            const bool blockEnabled = blockdata.scenes.lastSavedEnableValues[scene];
+            const bool blockEnabled = previousSceneWasActive
+                                    ? blockdata.scenes.lastSavedEnableValues[previousScene]
+                                    : blockdata.enabled;
 
             // revert temp scene state
             switch (blockdata.meta.enable.tempSceneState)
@@ -2558,14 +2690,14 @@ bool HostConnector::switchScene(const uint8_t scene)
                 --blockdata.meta.numParametersInScenes;
                 blockdata.meta.enable.hasScenes = false;
                 blockdata.meta.enable.tempSceneState = kTemporarySceneNone;
-                blockdata.scenes.enableValues[previousScene] = blockdata.scenes.lastSavedEnableValues[previousScene];
+                blockdata.scenes.enableValues[previousScene] = blockEnabled;
                 break;
             case kTemporarySceneClear:
                 assert(!blockdata.meta.enable.hasScenes);
                 ++blockdata.meta.numParametersInScenes;
                 blockdata.meta.enable.hasScenes = true;
                 blockdata.meta.enable.tempSceneState = kTemporarySceneNone;
-                blockdata.scenes.enableValues[previousScene] = blockdata.scenes.lastSavedEnableValues[previousScene];
+                blockdata.scenes.enableValues[previousScene] = blockEnabled;
                 break;
             }
 
@@ -2583,6 +2715,10 @@ bool HostConnector::switchScene(const uint8_t scene)
                 if ((paramdata.meta.flags & Lv2ParameterNotAllowedInScenes) != 0)
                     continue;
 
+                const float value = previousSceneWasActive
+                                  ? paramdata.scenes.lastSavedValues[previousScene]
+                                  : paramdata.value;
+
                 // revert temp scene state
                 switch (paramdata.meta.tempSceneState)
                 {
@@ -2593,22 +2729,25 @@ bool HostConnector::switchScene(const uint8_t scene)
                     --blockdata.meta.numParametersInScenes;
                     paramdata.meta.flags &= ~Lv2ParameterInScene;
                     paramdata.meta.tempSceneState = kTemporarySceneNone;
-                    paramdata.scenes.values[previousScene] = paramdata.scenes.lastSavedValues[previousScene];
+                    paramdata.scenes.values[previousScene] = value;
                     break;
                 case kTemporarySceneClear:
                     assert((paramdata.meta.flags & Lv2ParameterInScene) == 0);
                     ++blockdata.meta.numParametersInScenes;
                     paramdata.meta.flags |= Lv2ParameterInScene;
                     paramdata.meta.tempSceneState = kTemporarySceneNone;
-                    paramdata.scenes.values[previousScene] = paramdata.scenes.lastSavedValues[previousScene];
+                    paramdata.scenes.values[previousScene] = value;
                     break;
                 }
 
-                if (isNotEqual(paramdata.value, paramdata.scenes.lastSavedValues[scene]))
+                if (isNotEqual(paramdata.value, value))
                 {
-                    paramdata.value = paramdata.scenes.lastSavedValues[scene];
+                    paramdata.value = value;
                     params.push_back({ paramdata.symbol.c_str(), paramdata.value });
                 }
+
+                if (activateNewScene)
+                    paramdata.scenes.values[scene] = paramdata.scenes.lastSavedValues[scene] = value;
             }
 
             hostParamsFlushBlockPair(hbp, LV2_KXSTUDIO_PROPERTIES_RESET_NONE, params);
@@ -2619,6 +2758,9 @@ bool HostConnector::switchScene(const uint8_t scene)
                 blockdata.enabled = true;
                 hostBypassBlockPair(hbp, false);
             }
+
+            if (activateNewScene)
+                blockdata.scenes.enableValues[scene] = blockdata.scenes.enableValues[scene] = blockEnabled;
         }
     }
 
@@ -2687,11 +2829,12 @@ bool HostConnector::renameScene(const uint8_t scene, const char* const name)
     assert(scene < NUM_SCENES_PER_PRESET);
     assert(name != nullptr);
 
-    if (_current.sceneNames[scene] == name)
+    if (_current.scenes[scene].name == name)
         return false;
 
     _current.dirty = true;
-    _current.sceneNames[scene] = name;
+    _current.scenes[scene].active = true;
+    _current.scenes[scene].name = name;
     return true;
 }
 
@@ -5481,37 +5624,38 @@ void HostConnector::jsonPresetLoad(Preset& presetdata, const nlohmann::json& jpr
     // ----------------------------------------------------------------------------------------------------------------
     // sceneNames
 
-    if (jpreset.contains("sceneNames"))
-    {
-        const auto& jsceneNames = jpreset["sceneNames"];
-        std::string name;
-
-        for (uint8_t s = 0; s < NUM_SCENES_PER_PRESET; ++s)
-        {
-            const std::string jsceneid = std::to_string(s + 1);
-
-            if (jsceneNames.contains(jsceneid))
-            {
-                try {
-                    name = jsceneNames[jsceneid].get<std::string>();
-                } catch (...) {
-                    mod_log_warn("jsonPresetLoad(): preset contains invalid scene name");
-                    name.clear();
-                }
-
-                presetdata.sceneNames[s] = name;
-            }
-            else
-            {
-                presetdata.sceneNames[s].clear();
-            }
-        }
-    }
-    else
-    {
-        for (uint8_t s = 0; s < NUM_SCENES_PER_PRESET; ++s)
-            presetdata.sceneNames[s].clear();
-    }
+    // TODO
+    // if (jpreset.contains("sceneNames"))
+    // {
+    //     const auto& jsceneNames = jpreset["sceneNames"];
+    //     std::string name;
+    //
+    //     for (uint8_t s = 0; s < NUM_SCENES_PER_PRESET; ++s)
+    //     {
+    //         const std::string jsceneid = std::to_string(s + 1);
+    //
+    //         if (jsceneNames.contains(jsceneid))
+    //         {
+    //             try {
+    //                 name = jsceneNames[jsceneid].get<std::string>();
+    //             } catch (...) {
+    //                 mod_log_warn("jsonPresetLoad(): preset contains invalid scene name");
+    //                 name.clear();
+    //             }
+    //
+    //             presetdata.sceneNames[s] = name;
+    //         }
+    //         else
+    //         {
+    //             presetdata.sceneNames[s].clear();
+    //         }
+    //     }
+    // }
+    // else
+    // {
+    //     for (uint8_t s = 0; s < NUM_SCENES_PER_PRESET; ++s)
+    //         presetdata.sceneNames[s].clear();
+    // }
 
     // ----------------------------------------------------------------------------------------------------------------
     // uuid
@@ -5721,19 +5865,20 @@ void HostConnector::jsonPresetSave(const Preset& presetdata, nlohmann::json& jpr
     // ----------------------------------------------------------------------------------------------------------------
     // sceneNames
 
-    for (const std::string& sceneName : presetdata.sceneNames)
-    {
-        if (sceneName.empty())
-            continue;
-
-        auto& jsceneNames = jpreset["sceneNames"] = nlohmann::json::object({});
-        for (uint8_t s = 0; s < NUM_SCENES_PER_PRESET; ++s)
-        {
-            const std::string jsceneid = std::to_string(s + 1);
-            jsceneNames[jsceneid] = presetdata.sceneNames[s];
-        }
-        break;
-    }
+    // TODO
+    // for (const std::string& sceneName : presetdata.sceneNames)
+    // {
+    //     if (sceneName.empty())
+    //         continue;
+    //
+    //     auto& jsceneNames = jpreset["sceneNames"] = nlohmann::json::object({});
+    //     for (uint8_t s = 0; s < NUM_SCENES_PER_PRESET; ++s)
+    //     {
+    //         const std::string jsceneid = std::to_string(s + 1);
+    //         jsceneNames[jsceneid] = presetdata.sceneNames[s];
+    //     }
+    //     break;
+    // }
 }
 
 // --------------------------------------------------------------------------------------------------------------------
@@ -6887,7 +7032,10 @@ void HostConnector::resetPreset(Preset& preset)
     }
 
     for (uint8_t s = 0; s < NUM_SCENES_PER_PRESET; ++s)
-        preset.sceneNames[s].clear();
+    {
+        preset.scenes[s].active = false;
+        preset.scenes[s].name.clear();
+    }
 }
 
 void HostConnector::resetPresetPorts(Preset& preset, const bool usingDefault)

--- a/src/connector.cpp
+++ b/src/connector.cpp
@@ -2647,9 +2647,9 @@ void HostConnector::swapScenes(const uint8_t sceneA, const uint8_t sceneB)
 
 // --------------------------------------------------------------------------------------------------------------------
 
-bool HostConnector::switchScene(const uint8_t scene, const bool switchEvenIfSameScene)
+bool HostConnector::switchScene(const uint8_t scene, const bool switchEvenIfSameScene, const bool discardIfUnused)
 {
-    mod_log_debug("switchScene(%u, %s)", scene, bool2str(switchEvenIfSameScene));
+    mod_log_debug("switchScene(%u, %s, %s)", scene, bool2str(switchEvenIfSameScene), bool2str(discardIfUnused));
     assert(scene < NUM_SCENES_PER_PRESET);
 
     if (_current.scene == scene && ! switchEvenIfSameScene)
@@ -2676,7 +2676,7 @@ bool HostConnector::switchScene(const uint8_t scene, const bool switchEvenIfSame
     const uint8_t previousScene = _current.scene;
 
     if (_current.scenes[previousScene].state == kSceneInUseTemporarily)
-        _current.scenes[previousScene].state = kSceneUnused;
+        _current.scenes[previousScene].state = discardIfUnused ? kSceneUnused : kSceneInUse;
 
     _current.scene = scene;
 
@@ -2727,7 +2727,7 @@ bool HostConnector::switchScene(const uint8_t scene, const bool switchEvenIfSame
             }
 
             blockEnabled = activateNewScene || !blockdata.meta.enable.hasScenes
-                         ? blockdata.enabled
+                         ? blockdata.scenes.lastSavedEnableValues[_current.defaultScene]
                          : blockdata.scenes.enableValues[scene];
 
             // bypass/disable first if relevant
@@ -2766,7 +2766,7 @@ bool HostConnector::switchScene(const uint8_t scene, const bool switchEvenIfSame
                 }
 
                 paramValue = activateNewScene || (paramdata.meta.flags & Lv2ParameterInScene) == 0
-                           ? paramdata.value
+                           ? paramdata.scenes.lastSavedValues[_current.defaultScene]
                            : paramdata.scenes.values[scene];
 
                 if (isNotEqual(paramdata.value, paramValue))
@@ -7141,7 +7141,10 @@ void HostConnector::resetPreset(Preset& preset)
         preset.bindings[hwid].value = 0.0;
     }
 
-    for (uint8_t s = 0; s < NUM_SCENES_PER_PRESET; ++s)
+    preset.scenes[0].state = HostConnector::kSceneInUse;
+    preset.scenes[0].name.clear();
+
+    for (uint8_t s = 1; s < NUM_SCENES_PER_PRESET; ++s)
     {
         preset.scenes[s].state = HostConnector::kSceneUnused;
         preset.scenes[s].name.clear();

--- a/src/connector.cpp
+++ b/src/connector.cpp
@@ -2397,7 +2397,17 @@ void HostConnector::renamePreset(const uint8_t preset, const char* const name)
 
     nlohmann::json j;
     if (! loadPresetFromFile(filename.c_str(), j))
-        return;
+    {
+        try {
+            j = {};
+            j["version"] = JSON_PRESET_VERSION_CURRENT;
+            j["type"] = "preset";
+            j["preset"] = nlohmann::json::object({});
+        } catch (...) {
+            return;
+        }
+        jsonPresetSave(_presets[preset], j["preset"]);
+    }
 
     j["name"] = name;
     safeJsonSave(j, filename);

--- a/src/connector.cpp
+++ b/src/connector.cpp
@@ -2398,17 +2398,7 @@ void HostConnector::renamePreset(const uint8_t preset, const char* const name)
 
     nlohmann::json j;
     if (! loadPresetFromFile(filename.c_str(), j))
-    {
-        try {
-            j = {};
-            j["version"] = JSON_PRESET_VERSION_CURRENT;
-            j["type"] = "preset";
-            j["preset"] = nlohmann::json::object({});
-        } catch (...) {
-            return;
-        }
-        jsonPresetSave(_presets[preset], j["preset"]);
-    }
+        return;
 
     j["name"] = name;
     safeJsonSave(j, filename);

--- a/src/connector.hpp
+++ b/src/connector.hpp
@@ -693,7 +693,7 @@ public:
 
     // switch to another scene, which automatically activates it
     // returning false means the current chain was unchanged
-    bool switchScene(uint8_t scene, bool discardPrevious = false);
+    bool switchScene(uint8_t scene, bool switchEvenIfSameScene = false);
 
     // rename a scene
     bool renameScene(uint8_t scene, const char* name);

--- a/src/connector.hpp
+++ b/src/connector.hpp
@@ -10,6 +10,7 @@
 
 #include <cassert>
 #include <cstdint>
+#include <algorithm>
 #include <array>
 #include <list>
 #include <unordered_map>
@@ -1042,21 +1043,22 @@ static inline constexpr bool hasScenes(const HostBlock& block)
 
 static inline bool hasScenes(const HostBindings& bindings)
 {
-    for (const HostParameterBinding &binding : bindings.parameters)
-    {
-        if (binding.meta.isBypass)
+    return std::any_of(bindings.parameters.cbegin(),
+                       bindings.parameters.cend(),
+                       [](const HostParameterBinding &binding)
         {
-            if (hasScenes(binding.meta.block))
-                return true;
-        }
-        else
-        {
-            if (hasScenes(binding.meta.parameter))
-                return true;
-        }
-    }
-
-    return false;
+            if (binding.meta.isBypass)
+            {
+                if (hasScenes(binding.meta.block))
+                    return true;
+            }
+            else
+            {
+                if (hasScenes(binding.meta.parameter))
+                    return true;
+            }
+            return false;
+        });
 }
 
 // --------------------------------------------------------------------------------------------------------------------

--- a/src/connector.hpp
+++ b/src/connector.hpp
@@ -1045,7 +1045,10 @@ static inline constexpr bool hasScenes(const HostParameter& param)
 
 static inline constexpr bool hasScenes(const HostBlock& block)
 {
-    return block.meta.enable.hasScenes;
+    return block.meta.enable.hasScenes ||
+        std::any_of(block.parameters.cbegin(),
+                    block.parameters.cend(),
+                    [](const HostParameter &param) { return hasScenes(param); });
 }
 
 static inline bool hasScenes(const HostBindings& bindings)

--- a/src/connector.hpp
+++ b/src/connector.hpp
@@ -693,7 +693,7 @@ public:
 
     // switch to another scene, which automatically activates it
     // returning false means the current chain was unchanged
-    bool switchScene(uint8_t scene, bool switchEvenIfSameScene = false);
+    bool switchScene(uint8_t scene, bool switchEvenIfSameScene = false, bool discardIfUnused = true);
 
     // rename a scene
     bool renameScene(uint8_t scene, const char* name);

--- a/src/connector.hpp
+++ b/src/connector.hpp
@@ -216,7 +216,7 @@ struct HostConnector : Host::Callback {
         kSceneUnused = 0,
         // scene has been enabled temporarily
         // state will change to kSceneInUse if preset is saved
-        // data will be discarded if current/active scene changes without saving first
+        // data can be discarded if current/active scene changes without saving first (see `switchScene`)
         kSceneInUseTemporarily,
         // scene is in use
         kSceneInUse,

--- a/src/connector.hpp
+++ b/src/connector.hpp
@@ -1015,6 +1015,9 @@ private:
     // internal feedback handling, for updating parameter values
     void hostFeedbackCallback(const HostFeedbackData& data) override;
 
+    // internal scene data clear
+    void clearAllSceneData();
+
     // internal scene data copy, orig must be active
     // NOTE does not modify dest scene `name` and `state`
     void copySceneData(uint8_t orig, uint8_t dest);

--- a/src/connector.hpp
+++ b/src/connector.hpp
@@ -645,7 +645,7 @@ public:
    #endif
 
     // ----------------------------------------------------------------------------------------------------------------
-    // scene handling
+    // scene handling (within the current preset)
 
     // clear/delete all scenes
     void clearAllScenes();
@@ -653,20 +653,20 @@ public:
     // clear/delete a specific scene
     void clearScene(uint8_t scene);
 
-    // copy the contents of a scene into a new position (within the current preset)
+    // copy the contents of a scene into a new position
     bool copyScene(uint8_t orig, uint8_t dest);
 
-    // reorder/move a scene into a new position (within the current preset)
+    // reorder/move a scene into a new position
     bool reorderScenes(uint8_t orig, uint8_t dest);
 
-    // swap 2 scenes within the current preset
+    // swap 2 scenes
     void swapScenes(uint8_t sceneA, uint8_t sceneB);
 
-    // switch to another scene within the current preset
+    // switch to another scene, which automatically activates it
     // returning false means the current chain was unchanged
     bool switchScene(uint8_t scene, bool discardPrevious = false);
 
-    // rename a scene within the current preset
+    // rename a scene
     bool renameScene(uint8_t scene, const char* name);
 
     // convenience call for renaming current scene name
@@ -996,6 +996,9 @@ private:
 
     // internal feedback handling, for updating parameter values
     void hostFeedbackCallback(const HostFeedbackData& data) override;
+
+    // internal scene data copy, orig must be active
+    void copySceneData(uint8_t orig, uint8_t dest);
 
     // init block using plugin default values, optionally fill index maps
     void initBlock(Block& blockdata,

--- a/src/connector.hpp
+++ b/src/connector.hpp
@@ -184,9 +184,44 @@ struct HostConnector : Host::Callback {
         virtual void hostDisconnectedCallback() = 0;
     };
 
+    // scene operation mode that applies to parameter changes
+    // if a temporary mode was selected and then reverted, parameters revert to their `lastSavedValues`
+    enum SceneMode {
+        // enable scenes if not active yet
+        kSceneModeActivate,
+        // sync all parameter values in a scene, same as clearing it
+        kSceneModeClear,
+        // only update value, do not activate any scenes
+        kSceneModeUpdate,
+        // enable scenes if not active yet, but only temporarily
+        // scene value is discarded if preset is not saved
+        kSceneModeActivateTemporarily,
+        // sync all parameter values in a scene, same as clearing it, but only temporarily
+        // scene value is "uncleared" if preset is not saved
+        kSceneModeClearTemporarily,
+        // only update value, do not activate any scenes, but only temporarily
+        // scene value is discarded if preset is not saved
+        kSceneModeUpdateTemporarily,
+    };
+
+    enum SceneState : uint8_t {
+        // scene is not in use
+        kSceneUnused = 0,
+        // scene has been enabled temporarily
+        // state will change to kSceneInUse if preset is saved
+        // data will be discarded if current/active scene changes without saving first
+        kSceneInUseTemporarily,
+        // scene is in use
+        kSceneInUse,
+    };
+
+    // temporary scene state that applies to parameter changes
     enum TemporarySceneState : uint8_t {
+        // this parameter has no temporary scene state
         kTemporarySceneNone = 0,
+        // temporarily activate scene for a parameter, becoming part of scenes if saved
         kTemporarySceneActivate,
+        // temporarily clear scene for a parameter, clearing to be completed if saved
         kTemporarySceneClear,
     };
 
@@ -229,24 +264,6 @@ struct HostConnector : Host::Callback {
             CLASS_ONLY_MOVE_INIT_NO_COPY(Meta)
         } meta;
         CLASS_ONLY_MOVE_INIT_NO_COPY(Property)
-    };
-
-    enum SceneMode {
-        // enable scenes if not active yet
-        SceneModeActivate,
-        // sync all parameter values in a scene, same as clearing it
-        SceneModeClear,
-        // only update value, do not activate any scenes
-        SceneModeUpdate,
-        // enable scenes if not active yet, but only temporarily
-        // scene value is discarded if preset is not saved
-        SceneModeActivateTemporarily,
-        // sync all parameter values in a scene, same as clearing it, but only temporarily
-        // scene value is "uncleared" if preset is not saved
-        SceneModeClearTemporarily,
-        // only update value, do not activate any scenes, but only temporarily
-        // scene value is discarded if preset is not saved
-        SceneModeUpdateTemporarily,
     };
 
     struct Block {
@@ -346,7 +363,7 @@ struct HostConnector : Host::Callback {
 
     struct Scene {
         std::string name;
-        bool active;
+        SceneState state;
     };
 
     struct ChainRow {
@@ -760,7 +777,7 @@ public:
                            uint8_t block,
                            uint8_t paramIndex,
                            float value,
-                           SceneMode sceneMode = SceneModeClear);
+                           SceneMode sceneMode = kSceneModeClear);
 
     // set a block parameter value, based on port symbol
     // NOTE value must already be sanitized!
@@ -768,7 +785,7 @@ public:
                            uint8_t block,
                            const char* symbol,
                            float value,
-                           SceneMode sceneMode = SceneModeClear);
+                           SceneMode sceneMode = kSceneModeClear);
 
     // set a block quickpot
     void setBlockQuickPot(uint8_t row, uint8_t block, uint8_t paramIndex);
@@ -871,27 +888,16 @@ public:
     // WIP details below this point
 
     // set a block property, based on property index
-    void setBlockProperty(uint8_t row,
-                          uint8_t block,
-                          uint8_t propIndex,
-                          const char* value,
-                          SceneMode sceneMode = SceneModeClear);
+    void setBlockProperty(uint8_t row, uint8_t block, uint8_t propIndex, const char* value);
 
     // set a block property, based on property URI
-    void setBlockProperty(uint8_t row,
-                          uint8_t block,
-                          const char* uri,
-                          const char* value,
-                          SceneMode sceneMode = SceneModeClear);
+    void setBlockProperty(uint8_t row, uint8_t block, const char* uri, const char* value);
 
     // convenience calls for single-chain builds
    #if NUM_BLOCK_CHAIN_ROWS == 1
-    inline void setBlockProperty(const uint8_t block,
-                                 const uint8_t propIndex,
-                                 const char* const value,
-                                 const SceneMode sceneMode)
+    inline void setBlockProperty(const uint8_t block, const uint8_t propIndex, const char* const value)
     {
-        setBlockProperty(0, block, propIndex, value, sceneMode);
+        setBlockProperty(0, block, propIndex, value);
     }
    #endif
 
@@ -999,6 +1005,7 @@ private:
     void hostFeedbackCallback(const HostFeedbackData& data) override;
 
     // internal scene data copy, orig must be active
+    // NOTE does not modify dest scene `name` and `state`
     void copySceneData(uint8_t orig, uint8_t dest);
 
     // init block using plugin default values, optionally fill index maps

--- a/src/connector.hpp
+++ b/src/connector.hpp
@@ -343,6 +343,11 @@ struct HostConnector : Host::Callback {
         CLASS_ONLY_MOVE_INIT_NO_COPY(Bindings)
     };
 
+    struct Scene {
+        std::string name;
+        bool active;
+    };
+
     struct ChainRow {
         heap_array<Block, NUM_BLOCKS_PER_PRESET> blocks;
         std::array<std::string, 2> capture;
@@ -361,7 +366,7 @@ struct HostConnector : Host::Callback {
             uint32_t color;
             std::string style;
         } background;
-        heap_array<std::string, NUM_SCENES_PER_PRESET> sceneNames;
+        heap_array<Scene, NUM_SCENES_PER_PRESET> scenes;
         std::array<unsigned char, UUID_SIZE> uuid;
     private:
         friend struct HostConnector;
@@ -642,6 +647,15 @@ public:
     // ----------------------------------------------------------------------------------------------------------------
     // scene handling
 
+    // clear/delete all scenes
+    void clearAllScenes();
+
+    // clear/delete a specific scene
+    void clearScene(uint8_t scene);
+
+    // copy the contents of a scene into a new position (within the current preset)
+    bool copyScene(uint8_t orig, uint8_t dest);
+
     // reorder/move a scene into a new position (within the current preset)
     bool reorderScenes(uint8_t orig, uint8_t dest);
 
@@ -650,7 +664,7 @@ public:
 
     // switch to another scene within the current preset
     // returning false means the current chain was unchanged
-    bool switchScene(uint8_t scene);
+    bool switchScene(uint8_t scene, bool discardPrevious = false);
 
     // rename a scene within the current preset
     bool renameScene(uint8_t scene, const char* name);
@@ -1005,6 +1019,7 @@ using HostBlock = HostConnector::Block;
 using HostParameter = HostConnector::Parameter;
 using HostParameterBinding = HostConnector::ParameterBinding;
 using HostProperty = HostConnector::Property;
+using HostScene = HostConnector::Scene;
 using HostSceneMode = HostConnector::SceneMode;
 using HostCallbackData = HostConnector::Callback::Data;
 using HostNonBlockingScope = HostConnector::NonBlockingScope;

--- a/src/connector.hpp
+++ b/src/connector.hpp
@@ -1049,17 +1049,14 @@ using HostNonBlockingScopeWithAudioFades = HostConnector::NonBlockingScopeWithAu
 
 // --------------------------------------------------------------------------------------------------------------------
 
-static inline constexpr bool hasScenes(const HostParameter& param)
+inline constexpr bool hasScenes(const HostParameter& param)
 {
     return (param.meta.flags & Lv2ParameterInScene) != 0;
 }
 
-static inline constexpr bool hasScenes(const HostBlock& block)
+inline constexpr bool hasScenes(const HostBlock& block)
 {
-    return block.meta.enable.hasScenes ||
-        std::any_of(block.parameters.cbegin(),
-                    block.parameters.cend(),
-                    [](const HostParameter &param) { return hasScenes(param); });
+    return block.meta.numParametersInScenes != 0;
 }
 
 static inline bool hasScenes(const HostBindings& bindings)


### PR DESCRIPTION
Optimizations and tweaks for expanded number of scenes.

- don't set the param value for all scenes on "clear" mode (for 126 scenes this would be too much to do every time)
- add scene state value - unused, temp-in-use, in-use; use this to report which scenes are in-use vs empty
- add functions to clear and copy scenes
- some cleanup

To be defined:
- `HostConnector::renamePreset` was changed to allow to rename a non-existing preset, creating an empty one in that case. This might have been a misunderstanding though, need to check.

There is some code in comments still present in this PR, which I kept just in case we need to revert the optimization of "dont set all params all the time" due to side-effects.
