### PR TITLE
IPC emscripten websocket implementation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,7 +31,7 @@ pkg_check_modules(serialport IMPORTED_TARGET libserialport)
 # Setup connector target
 
 # check if we are building from this project, or are imported by another
-if(PROJECT_SOURCE_DIR STREQUAL CMAKE_SOURCE_DIR AND NOT MOD_CONNECTOR_TESTS)
+if(PROJECT_SOURCE_DIR STREQUAL CMAKE_SOURCE_DIR AND NOT MOD_CONNECTOR_LIB_ONLY)
 
   # building as regular application, uses Qt for event loop and notifies startup via systemd
   pkg_check_modules(systemd IMPORTED_TARGET libsystemd)

--- a/src/config.h
+++ b/src/config.h
@@ -98,3 +98,30 @@
 
 #define MOD_HOST_EFFECT_PREFIX "effect_"
 #define MOD_HOST_EFFECT_PREFIX_LEN 7
+
+// --------------------------------------------------------------------------------------------------------------------
+// test known configuration
+
+#ifdef _DARKGLASS_DEVICE_PABLITO
+
+#if NUM_BINDING_ACTUATORS != 10
+#error wrong NUM_BINDING_ACTUATORS
+#endif
+
+#if NUM_PRESETS_PER_BANK != 3
+#error wrong NUM_PRESETS_PER_BANK
+#endif
+
+#if NUM_SCENES_PER_PRESET != 126
+#error wrong NUM_SCENES_PER_PRESET
+#endif
+
+#if NUM_BLOCKS_PER_PRESET != 12
+#error wrong NUM_BLOCKS_PER_PRESET
+#endif
+
+#if NUM_BLOCK_CHAIN_ROWS != 2
+#error NUM_BLOCK_CHAIN_ROWS
+#endif
+
+#endif

--- a/src/connector.cpp
+++ b/src/connector.cpp
@@ -262,18 +262,18 @@ static constexpr const char* SceneMode2Str(const HostSceneMode sceneMode)
 {
     switch (sceneMode)
     {
-    case HostConnector::SceneModeActivate:
-        return "SceneModeActivate";
-    case HostConnector::SceneModeClear:
-        return "SceneModeClear";
-    case HostConnector::SceneModeUpdate:
-        return "SceneModeUpdate";
-    case HostConnector::SceneModeActivateTemporarily:
-        return "SceneModeActivateTemporarily";
-    case HostConnector::SceneModeClearTemporarily:
-        return "SceneModeClearTemporarily";
-    case HostConnector::SceneModeUpdateTemporarily:
-        return "SceneModeUpdateTemporarily";
+    case HostConnector::kSceneModeActivate:
+        return "kSceneModeActivate";
+    case HostConnector::kSceneModeClear:
+        return "kSceneModeClear";
+    case HostConnector::kSceneModeUpdate:
+        return "kSceneModeUpdate";
+    case HostConnector::kSceneModeActivateTemporarily:
+        return "kSceneModeActivateTemporarily";
+    case HostConnector::kSceneModeClearTemporarily:
+        return "kSceneModeClearTemporarily";
+    case HostConnector::kSceneModeUpdateTemporarily:
+        return "kSceneModeUpdateTemporarily";
     }
 
     return "";
@@ -1313,7 +1313,7 @@ bool HostConnector::enableBlock(const uint8_t row, const uint8_t block, const bo
 
         switch (sceneMode)
         {
-        case SceneModeActivate:
+        case kSceneModeActivate:
             if (! blockdata.meta.enable.hasScenes)
             {
                 ++blockdata.meta.numParametersInScenes;
@@ -1333,7 +1333,7 @@ bool HostConnector::enableBlock(const uint8_t row, const uint8_t block, const bo
             blockdata.scenes.lastSavedEnableValues[_current.scene] = enable;
             break;
 
-        case SceneModeActivateTemporarily:
+        case kSceneModeActivateTemporarily:
             if (! blockdata.meta.enable.hasScenes)
             {
                 ++blockdata.meta.numParametersInScenes;
@@ -1356,7 +1356,7 @@ bool HostConnector::enableBlock(const uint8_t row, const uint8_t block, const bo
             blockdata.scenes.enableValues[_current.scene] = enable;
             break;
 
-        case SceneModeClear:
+        case kSceneModeClear:
             if (blockdata.meta.enable.hasScenes)
             {
                 --blockdata.meta.numParametersInScenes;
@@ -1366,7 +1366,7 @@ bool HostConnector::enableBlock(const uint8_t row, const uint8_t block, const bo
             blockdata.scenes.lastSavedEnableValues.fill(enable);
             break;
 
-        case SceneModeClearTemporarily:
+        case kSceneModeClearTemporarily:
             if (blockdata.meta.enable.hasScenes)
             {
                 --blockdata.meta.numParametersInScenes;
@@ -1380,7 +1380,7 @@ bool HostConnector::enableBlock(const uint8_t row, const uint8_t block, const bo
             blockdata.scenes.enableValues.fill(enable);
             break;
 
-        case SceneModeUpdate:
+        case kSceneModeUpdate:
             if (! blockdata.meta.enable.hasScenes)
             {
                 blockdata.scenes.enableValues.fill(enable);
@@ -1393,12 +1393,19 @@ bool HostConnector::enableBlock(const uint8_t row, const uint8_t block, const bo
             }
             break;
 
-        case SceneModeUpdateTemporarily:
+        case kSceneModeUpdateTemporarily:
             if (! blockdata.meta.enable.hasScenes)
                 blockdata.scenes.enableValues.fill(enable);
             else
                 blockdata.scenes.enableValues[_current.scene] = enable;
             break;
+        }
+
+        if (_current.scenes[_current.scene].state == kSceneInUseTemporarily &&
+            blockdata.meta.enable.hasScenes &&
+            blockdata.meta.enable.tempSceneState == kTemporarySceneNone)
+        {
+            _current.scenes[_current.scene].state = kSceneInUse;
         }
     }
 
@@ -2375,9 +2382,9 @@ void HostConnector::clearAllScenes()
 
     for (uint8_t s = 0; s < NUM_SCENES_PER_PRESET; ++s)
     {
-        if (_current.scenes[s].active)
+        if (_current.scenes[s].state != HostConnector::kSceneUnused)
             continue;
-        _current.scenes[s].active = false;
+        _current.scenes[s].state = HostConnector::kSceneUnused;
         _current.scenes[s].name.clear();
         modified = true;
     }
@@ -2418,10 +2425,10 @@ void HostConnector::clearScene(const uint8_t scene)
     mod_log_debug("clearScene(%u)", scene);
     assert(scene < NUM_SCENES_PER_PRESET);
 
-    if (! _current.scenes[scene].active)
+    if (_current.scenes[scene].state == HostConnector::kSceneUnused)
         return;
 
-    _current.scenes[scene].active = false;
+    _current.scenes[scene].state = HostConnector::kSceneUnused;
     _current.scenes[scene].name.clear();
 
     _current.dirty = true;
@@ -2441,10 +2448,16 @@ bool HostConnector::copyScene(const uint8_t orig, const uint8_t dest)
         return false;
     }
 
-    if (_current.scenes[orig].active)
+    if (_current.scenes[orig].state != HostConnector::kSceneUnused)
+    {
+        _current.scenes[dest].name = _current.scenes[orig].name;
+        _current.scenes[dest].state = HostConnector::kSceneInUse;
         copySceneData(orig, dest);
+    }
     else
+    {
         clearScene(dest);
+    }
 
     _current.dirty = true;
     return true;
@@ -2615,16 +2628,23 @@ bool HostConnector::switchScene(const uint8_t scene, const bool discardPrevious)
     }
 
     const uint8_t previousScene = _current.scene;
-    const bool previousSceneWasActive =_current.scenes[previousScene].active;
-    const bool activateNewScene = !_current.scenes[scene].active;
+    const SceneState previousSceneState =_current.scenes[previousScene].state;
+
+    if (previousSceneState == kSceneInUseTemporarily)
+        _current.scenes[previousScene].state = kSceneUnused;
+
+    const bool activateNewScene = _current.scenes[scene].state == kSceneUnused;
 
     _current.scene = scene;
 
     if (activateNewScene)
     {
-        _current.scenes[scene].active = true;
         _current.scenes[scene].name = _current.scenes[previousScene].name;
+        _current.scenes[scene].state = kSceneInUseTemporarily;
     }
+
+    bool blockEnabled;
+    float paramValue;
 
     const Host::NonBlockingScope hnbs(_host);
 
@@ -2642,9 +2662,18 @@ bool HostConnector::switchScene(const uint8_t scene, const bool discardPrevious)
 
             params.clear();
 
-            const bool blockEnabled = previousSceneWasActive
-                                    ? blockdata.scenes.lastSavedEnableValues[previousScene]
-                                    : blockdata.enabled;
+            switch (previousSceneState)
+            {
+            case kSceneUnused:
+                blockEnabled = blockdata.enabled;
+                break;
+            case kSceneInUse:
+                blockEnabled = blockdata.scenes.enableValues[previousScene];
+                break;
+            case kSceneInUseTemporarily:
+                blockEnabled = blockdata.scenes.lastSavedEnableValues[previousScene];
+                break;
+            }
 
             // revert temp scene state
             switch (blockdata.meta.enable.tempSceneState)
@@ -2681,9 +2710,18 @@ bool HostConnector::switchScene(const uint8_t scene, const bool discardPrevious)
                 if ((paramdata.meta.flags & Lv2ParameterNotAllowedInScenes) != 0)
                     continue;
 
-                const float value = previousSceneWasActive
-                                  ? paramdata.scenes.lastSavedValues[previousScene]
-                                  : paramdata.value;
+                switch (previousSceneState)
+                {
+                case kSceneUnused:
+                    paramValue = paramdata.value;
+                    break;
+                case kSceneInUse:
+                    paramValue = paramdata.scenes.values[previousScene];
+                    break;
+                case kSceneInUseTemporarily:
+                    paramValue = paramdata.scenes.lastSavedValues[previousScene];
+                    break;
+                }
 
                 // revert temp scene state
                 switch (paramdata.meta.tempSceneState)
@@ -2695,25 +2733,25 @@ bool HostConnector::switchScene(const uint8_t scene, const bool discardPrevious)
                     --blockdata.meta.numParametersInScenes;
                     paramdata.meta.flags &= ~Lv2ParameterInScene;
                     paramdata.meta.tempSceneState = kTemporarySceneNone;
-                    paramdata.scenes.values[previousScene] = value;
+                    paramdata.scenes.values[previousScene] = paramValue;
                     break;
                 case kTemporarySceneClear:
                     assert((paramdata.meta.flags & Lv2ParameterInScene) == 0);
                     ++blockdata.meta.numParametersInScenes;
                     paramdata.meta.flags |= Lv2ParameterInScene;
                     paramdata.meta.tempSceneState = kTemporarySceneNone;
-                    paramdata.scenes.values[previousScene] = value;
+                    paramdata.scenes.values[previousScene] = paramValue;
                     break;
                 }
 
-                if (isNotEqual(paramdata.value, value))
+                if (isNotEqual(paramdata.value, paramValue))
                 {
-                    paramdata.value = value;
+                    paramdata.value = paramValue;
                     params.push_back({ paramdata.symbol.c_str(), paramdata.value });
                 }
 
                 if (activateNewScene)
-                    paramdata.scenes.values[scene] = paramdata.scenes.lastSavedValues[scene] = value;
+                    paramdata.scenes.values[scene] = paramdata.scenes.lastSavedValues[scene] = paramValue;
             }
 
             hostParamsFlushBlockPair(hbp, LV2_KXSTUDIO_PROPERTIES_RESET_NONE, params);
@@ -2798,12 +2836,12 @@ bool HostConnector::renameScene(const uint8_t scene, const char* const name)
     if (_current.scenes[scene].name == name)
         return false;
 
-    if (! _current.scenes[scene].active)
+    if (_current.scenes[scene].state == HostConnector::kSceneUnused)
     {
-        if (_current.scenes[_current.scene].active)
+        _current.scenes[scene].state = HostConnector::kSceneInUse;
+
+        if (_current.scenes[_current.scene].state != HostConnector::kSceneUnused)
             copySceneData(_current.scene, scene);
-        else
-            _current.scenes[scene].active = true;
     }
 
     _current.dirty = true;
@@ -3226,7 +3264,7 @@ bool HostConnector::replaceBlockBinding(const uint8_t hwid,
         else
         {
             // update block to match binding macro
-            enableBlock(rowB, blockB, _current.bindings[hwid].value > 0.5f, SceneModeUpdate);
+            enableBlock(rowB, blockB, _current.bindings[hwid].value > 0.5f, kSceneModeUpdate);
         }
 
         _current.dirty = true;
@@ -3327,7 +3365,7 @@ bool HostConnector::replaceBlockParameterBinding(const uint8_t hwid,
         {
             // update parameter value to match binding macro
             const float value = unnormalized(paramdataB.meta, _current.bindings[hwid].value);
-            setBlockParameter(rowB, blockB, paramIndexB, value, SceneModeUpdate);
+            setBlockParameter(rowB, blockB, paramIndexB, value, kSceneModeUpdate);
         }
 
         _current.dirty = true;
@@ -3546,7 +3584,7 @@ void HostConnector::setBlockParameter(const uint8_t row,
     {
         switch (sceneMode)
         {
-        case SceneModeActivate:
+        case kSceneModeActivate:
             if ((paramdata.meta.flags & Lv2ParameterInScene) == 0)
             {
                 ++blockdata.meta.numParametersInScenes;
@@ -3566,7 +3604,7 @@ void HostConnector::setBlockParameter(const uint8_t row,
             paramdata.scenes.lastSavedValues[_current.scene] = value;
             break;
 
-        case SceneModeActivateTemporarily:
+        case kSceneModeActivateTemporarily:
             if ((paramdata.meta.flags & Lv2ParameterInScene) == 0)
             {
                 ++blockdata.meta.numParametersInScenes;
@@ -3589,7 +3627,7 @@ void HostConnector::setBlockParameter(const uint8_t row,
             paramdata.scenes.values[_current.scene] = value;
             break;
 
-        case SceneModeClear:
+        case kSceneModeClear:
             if ((paramdata.meta.flags & Lv2ParameterInScene) != 0)
             {
                 --blockdata.meta.numParametersInScenes;
@@ -3599,7 +3637,7 @@ void HostConnector::setBlockParameter(const uint8_t row,
             paramdata.scenes.lastSavedValues.fill(value);
             break;
 
-        case SceneModeClearTemporarily:
+        case kSceneModeClearTemporarily:
             if ((paramdata.meta.flags & Lv2ParameterInScene) != 0)
             {
                 --blockdata.meta.numParametersInScenes;
@@ -3613,7 +3651,7 @@ void HostConnector::setBlockParameter(const uint8_t row,
             paramdata.scenes.values.fill(value);
             break;
 
-        case SceneModeUpdate:
+        case kSceneModeUpdate:
             if ((paramdata.meta.flags & Lv2ParameterInScene) == 0)
             {
                 paramdata.scenes.values.fill(value);
@@ -3626,12 +3664,19 @@ void HostConnector::setBlockParameter(const uint8_t row,
             }
             break;
 
-        case SceneModeUpdateTemporarily:
+        case kSceneModeUpdateTemporarily:
             if ((paramdata.meta.flags & Lv2ParameterInScene) == 0)
                 paramdata.scenes.values.fill(value);
             else
                 paramdata.scenes.values[_current.scene] = value;
             break;
+        }
+
+        if (_current.scenes[_current.scene].state == kSceneInUseTemporarily &&
+            (paramdata.meta.flags & Lv2ParameterInScene) != 0 &&
+            paramdata.meta.tempSceneState == kTemporarySceneNone)
+        {
+            _current.scenes[_current.scene].state = kSceneInUse;
         }
 
         if (paramdata.meta.hwbinding != UINT8_MAX)
@@ -4115,11 +4160,10 @@ void HostConnector::monitorToolOutputParameter(const uint8_t toolIndex, const ch
 void HostConnector::setBlockProperty(const uint8_t row,
                                      const uint8_t block,
                                      const uint8_t propIndex,
-                                     const char* const value,
-                                     const SceneMode sceneMode)
+                                     const char* const value)
 {
-    mod_log_debug("setBlockProperty(%u, %u, %u, \"%s\", %d:%s)",
-                  row, block, propIndex, value, sceneMode, SceneMode2Str(sceneMode));
+    mod_log_debug("setBlockProperty(%u, %u, %u, \"%s\")",
+                  row, block, propIndex, value);
     assert(row < NUM_BLOCK_CHAIN_ROWS);
     assert(block < NUM_BLOCKS_PER_PRESET);
     assert(propIndex < MAX_PARAMS_PER_BLOCK);
@@ -4148,11 +4192,10 @@ void HostConnector::setBlockProperty(const uint8_t row,
 void HostConnector::setBlockProperty(const uint8_t row,
                                      const uint8_t block,
                                      const char* const uri,
-                                     const char* const value,
-                                     const SceneMode sceneMode)
+                                     const char* const value)
 {
-    mod_log_debug("setBlockProperty(%u, %u, \"%s\", \"%s\", %d:%s)",
-                  row, block, uri, value, sceneMode, SceneMode2Str(sceneMode));
+    mod_log_debug("setBlockProperty(%u, %u, \"%s\", \"%s\")",
+                  row, block, uri, value);
     assert(row < NUM_BLOCK_CHAIN_ROWS);
     assert(block < NUM_BLOCKS_PER_PRESET);
     assert(uri != nullptr && *uri != '\0');
@@ -4169,7 +4212,7 @@ void HostConnector::setBlockProperty(const uint8_t row,
         return;
     }
 
-    setBlockProperty(row, block, propIndex, value, sceneMode);
+    setBlockProperty(row, block, propIndex, value);
 }
 
 // --------------------------------------------------------------------------------------------------------------------
@@ -5193,7 +5236,7 @@ void HostConnector::jsonPresetLoad(Preset& presetdata, const nlohmann::json& jpr
                                 }
 
                                 blockdata.scenes.enableValues[s] = enabled;
-                                presetdata.scenes[s].active = true;
+                                presetdata.scenes[s].state = HostConnector::kSceneInUse;
                             }
                         }
 
@@ -5258,7 +5301,7 @@ void HostConnector::jsonPresetLoad(Preset& presetdata, const nlohmann::json& jpr
                                     paramdata.scenes.values[s] = std::clamp<float>(value,
                                                                                    paramdata.meta.min,
                                                                                    paramdata.meta.max);
-                                    presetdata.scenes[s].active = true;
+                                    presetdata.scenes[s].state = HostConnector::kSceneInUse;
                                 }
                             }
                         }
@@ -6714,10 +6757,7 @@ void HostConnector::copySceneData(uint8_t orig, uint8_t dest)
 {
     assert(orig < NUM_SCENES_PER_PRESET);
     assert(dest < NUM_SCENES_PER_PRESET);
-    assert(_current.scenes[orig].active);
-
-    _current.scenes[dest].active = true;
-    _current.scenes[dest].name = _current.scenes[orig].name;
+    assert(_current.scenes[orig].state != HostConnector::kSceneUnused);
 
     for (uint8_t row = 0; row < NUM_BLOCK_CHAIN_ROWS; ++row)
     {
@@ -7052,7 +7092,7 @@ void HostConnector::resetPreset(Preset& preset)
 
     for (uint8_t s = 0; s < NUM_SCENES_PER_PRESET; ++s)
     {
-        preset.scenes[s].active = false;
+        preset.scenes[s].state = HostConnector::kSceneUnused;
         preset.scenes[s].name.clear();
     }
 }

--- a/src/connector.cpp
+++ b/src/connector.cpp
@@ -1331,6 +1331,7 @@ bool HostConnector::enableBlock(const uint8_t row, const uint8_t block, const bo
             // set new value for current scene
             blockdata.scenes.enableValues[_current.scene] = enable;
             blockdata.scenes.lastSavedEnableValues[_current.scene] = enable;
+            assert(blockdata.meta.enable.tempSceneState == kTemporarySceneNone);
             break;
 
         case kSceneModeActivateTemporarily:
@@ -1364,6 +1365,7 @@ bool HostConnector::enableBlock(const uint8_t row, const uint8_t block, const bo
             }
             blockdata.scenes.enableValues.fill(enable);
             blockdata.scenes.lastSavedEnableValues.fill(enable);
+            assert(blockdata.meta.enable.tempSceneState == kTemporarySceneNone);
             break;
 
         case kSceneModeClearTemporarily:
@@ -1391,6 +1393,7 @@ bool HostConnector::enableBlock(const uint8_t row, const uint8_t block, const bo
                 blockdata.scenes.enableValues[_current.scene] = enable;
                 blockdata.scenes.lastSavedEnableValues[_current.scene] = enable;
             }
+            assert(blockdata.meta.enable.tempSceneState == kTemporarySceneNone);
             break;
 
         case kSceneModeUpdateTemporarily:
@@ -1401,12 +1404,8 @@ bool HostConnector::enableBlock(const uint8_t row, const uint8_t block, const bo
             break;
         }
 
-        if (_current.scenes[_current.scene].state == kSceneInUseTemporarily &&
-            blockdata.meta.enable.hasScenes &&
-            blockdata.meta.enable.tempSceneState == kTemporarySceneNone)
-        {
+        if (blockdata.meta.enable.hasScenes && blockdata.meta.enable.tempSceneState == kTemporarySceneNone)
             _current.scenes[_current.scene].state = kSceneInUse;
-        }
     }
 
     if (blockdata.meta.enable.hwbinding != UINT8_MAX)
@@ -2628,9 +2627,8 @@ bool HostConnector::switchScene(const uint8_t scene, const bool discardPrevious)
     }
 
     const uint8_t previousScene = _current.scene;
-    const SceneState previousSceneState =_current.scenes[previousScene].state;
 
-    if (previousSceneState == kSceneInUseTemporarily)
+    if (_current.scenes[previousScene].state == kSceneInUseTemporarily)
         _current.scenes[previousScene].state = kSceneUnused;
 
     const bool activateNewScene = _current.scenes[scene].state == kSceneUnused;
@@ -2662,18 +2660,7 @@ bool HostConnector::switchScene(const uint8_t scene, const bool discardPrevious)
 
             params.clear();
 
-            switch (previousSceneState)
-            {
-            case kSceneUnused:
-                blockEnabled = blockdata.enabled;
-                break;
-            case kSceneInUse:
-                blockEnabled = blockdata.scenes.enableValues[previousScene];
-                break;
-            case kSceneInUseTemporarily:
-                blockEnabled = blockdata.scenes.lastSavedEnableValues[previousScene];
-                break;
-            }
+            blockEnabled = activateNewScene ? blockdata.enabled : blockdata.scenes.enableValues[scene];
 
             // revert temp scene state
             switch (blockdata.meta.enable.tempSceneState)
@@ -2685,14 +2672,14 @@ bool HostConnector::switchScene(const uint8_t scene, const bool discardPrevious)
                 --blockdata.meta.numParametersInScenes;
                 blockdata.meta.enable.hasScenes = false;
                 blockdata.meta.enable.tempSceneState = kTemporarySceneNone;
-                blockdata.scenes.enableValues[previousScene] = blockEnabled;
+                blockdata.scenes.enableValues[previousScene] = blockdata.scenes.lastSavedEnableValues[previousScene];
                 break;
             case kTemporarySceneClear:
                 assert(!blockdata.meta.enable.hasScenes);
                 ++blockdata.meta.numParametersInScenes;
                 blockdata.meta.enable.hasScenes = true;
                 blockdata.meta.enable.tempSceneState = kTemporarySceneNone;
-                blockdata.scenes.enableValues[previousScene] = blockEnabled;
+                blockdata.scenes.enableValues[previousScene] = blockdata.scenes.lastSavedEnableValues[previousScene];
                 break;
             }
 
@@ -2710,19 +2697,6 @@ bool HostConnector::switchScene(const uint8_t scene, const bool discardPrevious)
                 if ((paramdata.meta.flags & Lv2ParameterNotAllowedInScenes) != 0)
                     continue;
 
-                switch (previousSceneState)
-                {
-                case kSceneUnused:
-                    paramValue = paramdata.value;
-                    break;
-                case kSceneInUse:
-                    paramValue = paramdata.scenes.values[previousScene];
-                    break;
-                case kSceneInUseTemporarily:
-                    paramValue = paramdata.scenes.lastSavedValues[previousScene];
-                    break;
-                }
-
                 // revert temp scene state
                 switch (paramdata.meta.tempSceneState)
                 {
@@ -2733,16 +2707,18 @@ bool HostConnector::switchScene(const uint8_t scene, const bool discardPrevious)
                     --blockdata.meta.numParametersInScenes;
                     paramdata.meta.flags &= ~Lv2ParameterInScene;
                     paramdata.meta.tempSceneState = kTemporarySceneNone;
-                    paramdata.scenes.values[previousScene] = paramValue;
+                    paramdata.scenes.values[previousScene] = paramdata.scenes.lastSavedValues[previousScene];
                     break;
                 case kTemporarySceneClear:
                     assert((paramdata.meta.flags & Lv2ParameterInScene) == 0);
                     ++blockdata.meta.numParametersInScenes;
                     paramdata.meta.flags |= Lv2ParameterInScene;
                     paramdata.meta.tempSceneState = kTemporarySceneNone;
-                    paramdata.scenes.values[previousScene] = paramValue;
+                    paramdata.scenes.values[previousScene] = paramdata.scenes.lastSavedValues[previousScene];
                     break;
                 }
+
+                paramValue = activateNewScene ? paramdata.value : paramdata.scenes.values[scene];
 
                 if (isNotEqual(paramdata.value, paramValue))
                 {
@@ -3602,6 +3578,7 @@ void HostConnector::setBlockParameter(const uint8_t row,
             // set new value for current scene
             paramdata.scenes.values[_current.scene] = value;
             paramdata.scenes.lastSavedValues[_current.scene] = value;
+            assert(paramdata.meta.tempSceneState == kTemporarySceneNone);
             break;
 
         case kSceneModeActivateTemporarily:
@@ -3635,6 +3612,7 @@ void HostConnector::setBlockParameter(const uint8_t row,
             }
             paramdata.scenes.values.fill(value);
             paramdata.scenes.lastSavedValues.fill(value);
+            assert(paramdata.meta.tempSceneState == kTemporarySceneNone);
             break;
 
         case kSceneModeClearTemporarily:
@@ -3662,6 +3640,7 @@ void HostConnector::setBlockParameter(const uint8_t row,
                 paramdata.scenes.values[_current.scene] = value;
                 paramdata.scenes.lastSavedValues[_current.scene] = value;
             }
+            assert(paramdata.meta.tempSceneState == kTemporarySceneNone);
             break;
 
         case kSceneModeUpdateTemporarily:
@@ -3672,12 +3651,8 @@ void HostConnector::setBlockParameter(const uint8_t row,
             break;
         }
 
-        if (_current.scenes[_current.scene].state == kSceneInUseTemporarily &&
-            (paramdata.meta.flags & Lv2ParameterInScene) != 0 &&
-            paramdata.meta.tempSceneState == kTemporarySceneNone)
-        {
+        if ((paramdata.meta.flags & Lv2ParameterInScene) != 0 && paramdata.meta.tempSceneState == kTemporarySceneNone)
             _current.scenes[_current.scene].state = kSceneInUse;
-        }
 
         if (paramdata.meta.hwbinding != UINT8_MAX)
         {

--- a/src/connector.cpp
+++ b/src/connector.cpp
@@ -2866,7 +2866,7 @@ bool HostConnector::renameScene(const uint8_t scene, const char* const name)
         _current.scenes[scene].state = HostConnector::kSceneInUse;
 
         if (_current.scenes[_current.scene].state != HostConnector::kSceneUnused)
-            copySceneData(_current.scene, scene);
+            copySceneData(_current.defaultScene, scene);
     }
 
     _current.dirty = true;

--- a/src/connector.cpp
+++ b/src/connector.cpp
@@ -2430,7 +2430,12 @@ void HostConnector::clearAllScenes()
         modified = true;
     }
 
-    _current.defaultScene = 0;
+    if (_current.defaultScene != 0)
+    {
+        _current.defaultScene = 0;
+        modified = true;
+    }
+
     _current.scenes[0].state = HostConnector::kSceneInUse;
 
     if (modified)

--- a/src/connector.cpp
+++ b/src/connector.cpp
@@ -2705,8 +2705,6 @@ bool HostConnector::switchScene(const uint8_t scene, const bool switchEvenIfSame
 
             params.clear();
 
-            blockEnabled = activateNewScene ? blockdata.enabled : blockdata.scenes.enableValues[scene];
-
             // revert temp scene state
             switch (blockdata.meta.enable.tempSceneState)
             {
@@ -2727,6 +2725,10 @@ bool HostConnector::switchScene(const uint8_t scene, const bool switchEvenIfSame
                 blockdata.scenes.enableValues[previousScene] = blockdata.scenes.lastSavedEnableValues[previousScene];
                 break;
             }
+
+            blockEnabled = activateNewScene || !blockdata.meta.enable.hasScenes
+                         ? blockdata.enabled
+                         : blockdata.scenes.enableValues[scene];
 
             // bypass/disable first if relevant
             if (blockdata.enabled != blockEnabled && !blockEnabled)
@@ -2763,7 +2765,9 @@ bool HostConnector::switchScene(const uint8_t scene, const bool switchEvenIfSame
                     break;
                 }
 
-                paramValue = activateNewScene ? paramdata.value : paramdata.scenes.values[scene];
+                paramValue = activateNewScene || (paramdata.meta.flags & Lv2ParameterInScene) == 0
+                           ? paramdata.value
+                           : paramdata.scenes.values[scene];
 
                 if (isNotEqual(paramdata.value, paramValue))
                 {

--- a/src/connector.cpp
+++ b/src/connector.cpp
@@ -2546,6 +2546,17 @@ bool HostConnector::reorderScenes(const uint8_t orig, const uint8_t dest)
 
                 vector_bool_swap(blockdata.scenes.enableValues, sceneA, sceneB);
                 vector_bool_swap(blockdata.scenes.lastSavedEnableValues, sceneA, sceneB);
+
+                for (Parameter& paramdata : blockdata.parameters)
+                {
+                    if (isNullURI(paramdata.symbol))
+                        break;
+                    if ((paramdata.meta.flags & Lv2ParameterNotAllowedInScenes) != 0)
+                        continue;
+
+                    std::swap(paramdata.scenes.values[sceneA], paramdata.scenes.values[sceneB]);
+                    std::swap(paramdata.scenes.lastSavedValues[sceneA], paramdata.scenes.lastSavedValues[sceneB]);
+                }
             }
         }
 
@@ -2624,6 +2635,17 @@ void HostConnector::swapScenes(const uint8_t sceneA, const uint8_t sceneB)
 
             vector_bool_swap(blockdata.scenes.enableValues, sceneA, sceneB);
             vector_bool_swap(blockdata.scenes.lastSavedEnableValues, sceneA, sceneB);
+
+            for (Parameter& paramdata : blockdata.parameters)
+            {
+                if (isNullURI(paramdata.symbol))
+                    break;
+                if ((paramdata.meta.flags & Lv2ParameterNotAllowedInScenes) != 0)
+                    continue;
+
+                std::swap(paramdata.scenes.values[sceneA], paramdata.scenes.values[sceneB]);
+                std::swap(paramdata.scenes.lastSavedValues[sceneA], paramdata.scenes.lastSavedValues[sceneB]);
+            }
         }
     }
 

--- a/src/connector.cpp
+++ b/src/connector.cpp
@@ -475,6 +475,14 @@ void HostConnector::setCallback(Callback* const callback)
 
 // --------------------------------------------------------------------------------------------------------------------
 
+void HostConnector::disconnect()
+{
+    ok = false;
+    _host.close();
+}
+
+// --------------------------------------------------------------------------------------------------------------------
+
 bool HostConnector::reconnect()
 {
     ok = _host.reconnect();

--- a/src/connector.cpp
+++ b/src/connector.cpp
@@ -5706,6 +5706,7 @@ void HostConnector::jsonPresetLoad(Preset& presetdata, const nlohmann::json& jpr
                 }
 
                 presetdata.scenes[s].name = name;
+                presetdata.scenes[s].state = HostConnector::kSceneInUse;
             }
             else
             {
@@ -5717,6 +5718,10 @@ void HostConnector::jsonPresetLoad(Preset& presetdata, const nlohmann::json& jpr
     {
         for (Scene& scenedata : presetdata.scenes)
             scenedata.name.clear();
+
+        // scene names not included, typically means no scenes present
+        // make sure to activate the first scene as to match new-preset behaviour
+        presetdata.scenes[0].state = HostConnector::kSceneInUse;
     }
 
     // ----------------------------------------------------------------------------------------------------------------

--- a/src/connector.cpp
+++ b/src/connector.cpp
@@ -1081,6 +1081,12 @@ bool HostConnector::saveCurrentPresetToFile(const char* const filename)
                 }
             }
         }
+
+        for (uint8_t s = 0; s < NUM_SCENES_PER_PRESET; ++s)
+        {
+            if (_current.scenes[s].state == kSceneInUseTemporarily)
+                _current.scenes[s].state = kSceneInUse;
+        }
     }
 
     // copy current data into preset data
@@ -1389,8 +1395,8 @@ bool HostConnector::enableBlock(const uint8_t row, const uint8_t block, const bo
                 --blockdata.meta.numParametersInScenes;
                 blockdata.meta.enable.hasScenes = false;
             }
-            blockdata.scenes.enableValues.fill(enable);
-            blockdata.scenes.lastSavedEnableValues.fill(enable);
+            // blockdata.scenes.enableValues.fill(enable);
+            // blockdata.scenes.lastSavedEnableValues.fill(enable);
             assert(blockdata.meta.enable.tempSceneState == kTemporarySceneNone);
             break;
 
@@ -1405,16 +1411,16 @@ bool HostConnector::enableBlock(const uint8_t row, const uint8_t block, const bo
                                                     ? kTemporarySceneClear
                                                     : kTemporarySceneNone;
             }
-            blockdata.scenes.enableValues.fill(enable);
+            // blockdata.scenes.enableValues.fill(enable);
             break;
 
         case kSceneModeUpdate:
-            if (! blockdata.meta.enable.hasScenes)
-            {
-                blockdata.scenes.enableValues.fill(enable);
-                blockdata.scenes.lastSavedEnableValues.fill(enable);
-            }
-            else
+            if (blockdata.meta.enable.hasScenes)
+            // {
+            //     blockdata.scenes.enableValues.fill(enable);
+            //     blockdata.scenes.lastSavedEnableValues.fill(enable);
+            // }
+            // else
             {
                 blockdata.scenes.enableValues[_current.scene] = enable;
                 blockdata.scenes.lastSavedEnableValues[_current.scene] = enable;
@@ -1423,9 +1429,9 @@ bool HostConnector::enableBlock(const uint8_t row, const uint8_t block, const bo
             break;
 
         case kSceneModeUpdateTemporarily:
-            if (! blockdata.meta.enable.hasScenes)
-                blockdata.scenes.enableValues.fill(enable);
-            else
+            if (blockdata.meta.enable.hasScenes)
+            //     blockdata.scenes.enableValues.fill(enable);
+            // else
                 blockdata.scenes.enableValues[_current.scene] = enable;
             break;
         }
@@ -2438,6 +2444,9 @@ void HostConnector::clearAllScenes()
 
                 paramdata.meta.flags &= ~Lv2ParameterInScene;
                 paramdata.meta.tempSceneState = kTemporarySceneNone;
+
+                // paramdata.scenes.values.fill(paramdata.value);
+                // paramdata.scenes.lastSavedValues.fill(paramdata.value);
             }
         }
     }
@@ -2766,7 +2775,7 @@ bool HostConnector::switchScene(const uint8_t scene, const bool discardPrevious)
             }
 
             if (activateNewScene)
-                blockdata.scenes.enableValues[scene] = blockdata.scenes.enableValues[scene] = blockEnabled;
+                blockdata.scenes.enableValues[scene] = blockdata.scenes.lastSavedEnableValues[scene] = blockEnabled;
         }
     }
 
@@ -3636,8 +3645,8 @@ void HostConnector::setBlockParameter(const uint8_t row,
                 --blockdata.meta.numParametersInScenes;
                 paramdata.meta.flags &= ~Lv2ParameterInScene;
             }
-            paramdata.scenes.values.fill(value);
-            paramdata.scenes.lastSavedValues.fill(value);
+            // paramdata.scenes.values.fill(value);
+            // paramdata.scenes.lastSavedValues.fill(value);
             assert(paramdata.meta.tempSceneState == kTemporarySceneNone);
             break;
 
@@ -3652,16 +3661,16 @@ void HostConnector::setBlockParameter(const uint8_t row,
                                               ? kTemporarySceneClear
                                               : kTemporarySceneNone;
             }
-            paramdata.scenes.values.fill(value);
+            // paramdata.scenes.values.fill(value);
             break;
 
         case kSceneModeUpdate:
-            if ((paramdata.meta.flags & Lv2ParameterInScene) == 0)
-            {
-                paramdata.scenes.values.fill(value);
-                paramdata.scenes.lastSavedValues.fill(value);
-            }
-            else
+            if ((paramdata.meta.flags & Lv2ParameterInScene) != 0)
+            // {
+            //     paramdata.scenes.values.fill(value);
+            //     paramdata.scenes.lastSavedValues.fill(value);
+            // }
+            // else
             {
                 paramdata.scenes.values[_current.scene] = value;
                 paramdata.scenes.lastSavedValues[_current.scene] = value;
@@ -3670,9 +3679,9 @@ void HostConnector::setBlockParameter(const uint8_t row,
             break;
 
         case kSceneModeUpdateTemporarily:
-            if ((paramdata.meta.flags & Lv2ParameterInScene) == 0)
-                paramdata.scenes.values.fill(value);
-            else
+            if ((paramdata.meta.flags & Lv2ParameterInScene) != 0)
+            //     paramdata.scenes.values.fill(value);
+            // else
                 paramdata.scenes.values[_current.scene] = value;
             break;
         }
@@ -5790,6 +5799,9 @@ void HostConnector::jsonPresetSave(const Preset& presetdata, nlohmann::json& jpr
                 if (isNullBlock(blockdata))
                     continue;
 
+                // save operation must have converted these already
+                assert(blockdata.meta.enable.tempSceneState == kTemporarySceneNone);
+
                 const std::string jblockid = std::to_string(bl + 1);
                 auto& jblock = jblocks[jblockid] = nlohmann::json::object({
                     { "parameters", nlohmann::json::object({}) },
@@ -5812,6 +5824,9 @@ void HostConnector::jsonPresetSave(const Preset& presetdata, nlohmann::json& jpr
                             break;
                         if (! shouldSaveParameterToPreset(paramdata.meta.flags))
                             continue;
+
+                        // save operation must have converted these already
+                        assert(paramdata.meta.tempSceneState == kTemporarySceneNone);
 
                         const std::string jparamid = std::to_string(++jp);
                         jparams[jparamid] = nlohmann::json::object({
@@ -5843,12 +5858,18 @@ void HostConnector::jsonPresetSave(const Preset& presetdata, nlohmann::json& jpr
                     }
                 }
 
-                if (blockdata.meta.numParametersInScenes != 0)
+                if (hasScenes(blockdata))
                 {
                     auto& jscenes = jblock["scenes"];
 
                     for (uint8_t s = 0; s < NUM_SCENES_PER_PRESET; ++s)
                     {
+                        // save operation must have converted these already
+                        assert(presetdata.scenes[s].state != kSceneInUseTemporarily);
+
+                        if (presetdata.scenes[s].state == kSceneUnused)
+                            continue;
+
                         const std::string jsceneid = std::to_string(s + 1);
                         auto& jscene = jscenes[jsceneid] = nlohmann::json::object({
                             { "parameters", nlohmann::json::array() },
@@ -7145,8 +7166,8 @@ void HostConnector::setEnableChangesNotSavedToPreset(Block& blockdata, const boo
         --blockdata.meta.numParametersInScenes;
         blockdata.meta.enable.hasScenes = false;
     }
-    blockdata.scenes.enableValues.fill(blockdata.enabled);
-    blockdata.scenes.lastSavedEnableValues.fill(blockdata.enabled);
+    // blockdata.scenes.enableValues.fill(blockdata.enabled);
+    // blockdata.scenes.lastSavedEnableValues.fill(blockdata.enabled);
 }
 
 void HostConnector::setParamChangesNotSavedToPreset(Block& blockdata,
@@ -7169,8 +7190,8 @@ void HostConnector::setParamChangesNotSavedToPreset(Block& blockdata,
         --blockdata.meta.numParametersInScenes;
         paramdata.meta.flags &= ~Lv2ParameterInScene;
     }
-    paramdata.scenes.values.fill(paramdata.value);
-    paramdata.scenes.lastSavedValues.fill(paramdata.value);
+    // paramdata.scenes.values.fill(paramdata.value);
+    // paramdata.scenes.lastSavedValues.fill(paramdata.value);
 }
 
 // --------------------------------------------------------------------------------------------------------------------

--- a/src/connector.cpp
+++ b/src/connector.cpp
@@ -2485,13 +2485,13 @@ void HostConnector::clearScene(const uint8_t scene)
 
 bool HostConnector::copyScene(const uint8_t orig, const uint8_t dest)
 {
-    mod_log_debug("reorderScenes(%u, %u)", orig, dest);
+    mod_log_debug("copyScene(%u, %u)", orig, dest);
     assert(orig < NUM_SCENES_PER_PRESET);
     assert(dest < NUM_SCENES_PER_PRESET);
 
     if (orig == dest)
     {
-        mod_log_warn("reorderScenes(%u, %u) - orig == dest, rejected", orig, dest);
+        mod_log_warn("copyScene(%u, %u) - orig == dest, rejected", orig, dest);
         return false;
     }
 

--- a/src/connector.cpp
+++ b/src/connector.cpp
@@ -5941,18 +5941,17 @@ void HostConnector::jsonPresetSave(const Preset& presetdata, nlohmann::json& jpr
 
     if (std::any_of(presetdata.scenes.cbegin(),
                     presetdata.scenes.cend(),
-                    [](const Scene& scenedata){ return !scenedata.name.empty(); }))
+                    [](const Scene& scenedata){ return scenedata.state != kSceneUnused; }))
     {
         auto& jsceneNames = jpreset["sceneNames"] = nlohmann::json::object({});
 
-        std::string name;
         std::string jsceneid;
         for (uint8_t s = 0; s < NUM_SCENES_PER_PRESET; ++s)
         {
-            if (name = presetdata.scenes[s].name; !name.empty())
+            if (presetdata.scenes[s].state != kSceneUnused)
             {
                 jsceneid = std::to_string(s + 1);
-                jsceneNames[jsceneid] = name;
+                jsceneNames[jsceneid] = presetdata.scenes[s].name;
             }
         }
     }

--- a/src/connector.cpp
+++ b/src/connector.cpp
@@ -5193,6 +5193,7 @@ void HostConnector::jsonPresetLoad(Preset& presetdata, const nlohmann::json& jpr
                                 }
 
                                 blockdata.scenes.enableValues[s] = enabled;
+                                presetdata.scenes[s].active = true;
                             }
                         }
 
@@ -5257,6 +5258,7 @@ void HostConnector::jsonPresetLoad(Preset& presetdata, const nlohmann::json& jpr
                                     paramdata.scenes.values[s] = std::clamp<float>(value,
                                                                                    paramdata.meta.min,
                                                                                    paramdata.meta.max);
+                                    presetdata.scenes[s].active = true;
                                 }
                             }
                         }
@@ -5597,38 +5599,38 @@ void HostConnector::jsonPresetLoad(Preset& presetdata, const nlohmann::json& jpr
     // ----------------------------------------------------------------------------------------------------------------
     // sceneNames
 
-    // TODO
-    // if (jpreset.contains("sceneNames"))
-    // {
-    //     const auto& jsceneNames = jpreset["sceneNames"];
-    //     std::string name;
-    //
-    //     for (uint8_t s = 0; s < NUM_SCENES_PER_PRESET; ++s)
-    //     {
-    //         const std::string jsceneid = std::to_string(s + 1);
-    //
-    //         if (jsceneNames.contains(jsceneid))
-    //         {
-    //             try {
-    //                 name = jsceneNames[jsceneid].get<std::string>();
-    //             } catch (...) {
-    //                 mod_log_warn("jsonPresetLoad(): preset contains invalid scene name");
-    //                 name.clear();
-    //             }
-    //
-    //             presetdata.sceneNames[s] = name;
-    //         }
-    //         else
-    //         {
-    //             presetdata.sceneNames[s].clear();
-    //         }
-    //     }
-    // }
-    // else
-    // {
-    //     for (uint8_t s = 0; s < NUM_SCENES_PER_PRESET; ++s)
-    //         presetdata.sceneNames[s].clear();
-    // }
+    if (jpreset.contains("sceneNames"))
+    {
+        const auto& jsceneNames = jpreset["sceneNames"];
+        std::string jsceneid;
+        std::string name;
+
+        for (uint8_t s = 0; s < NUM_SCENES_PER_PRESET; ++s)
+        {
+            jsceneid = std::to_string(s + 1);
+
+            if (jsceneNames.contains(jsceneid))
+            {
+                try {
+                    name = jsceneNames[jsceneid].get<std::string>();
+                } catch (...) {
+                    mod_log_warn("jsonPresetLoad(): preset contains invalid scene name");
+                    name.clear();
+                }
+
+                presetdata.scenes[s].name = name;
+            }
+            else
+            {
+                presetdata.scenes[s].name.clear();
+            }
+        }
+    }
+    else
+    {
+        for (Scene& scenedata : presetdata.scenes)
+            scenedata.name.clear();
+    }
 
     // ----------------------------------------------------------------------------------------------------------------
     // uuid
@@ -5838,20 +5840,23 @@ void HostConnector::jsonPresetSave(const Preset& presetdata, nlohmann::json& jpr
     // ----------------------------------------------------------------------------------------------------------------
     // sceneNames
 
-    // TODO
-    // for (const std::string& sceneName : presetdata.sceneNames)
-    // {
-    //     if (sceneName.empty())
-    //         continue;
-    //
-    //     auto& jsceneNames = jpreset["sceneNames"] = nlohmann::json::object({});
-    //     for (uint8_t s = 0; s < NUM_SCENES_PER_PRESET; ++s)
-    //     {
-    //         const std::string jsceneid = std::to_string(s + 1);
-    //         jsceneNames[jsceneid] = presetdata.sceneNames[s];
-    //     }
-    //     break;
-    // }
+    if (std::any_of(presetdata.scenes.cbegin(),
+                    presetdata.scenes.cend(),
+                    [](const Scene& scenedata){ return !scenedata.name.empty(); }))
+    {
+        auto& jsceneNames = jpreset["sceneNames"] = nlohmann::json::object({});
+
+        std::string name;
+        std::string jsceneid;
+        for (uint8_t s = 0; s < NUM_SCENES_PER_PRESET; ++s)
+        {
+            if (name = presetdata.scenes[s].name; !name.empty())
+            {
+                jsceneid = std::to_string(s + 1);
+                jsceneNames[jsceneid] = name;
+            }
+        }
+    }
 }
 
 // --------------------------------------------------------------------------------------------------------------------

--- a/src/connector.cpp
+++ b/src/connector.cpp
@@ -2430,6 +2430,9 @@ void HostConnector::clearAllScenes()
         modified = true;
     }
 
+    _current.defaultScene = 0;
+    _current.scenes[0].state = HostConnector::kSceneInUse;
+
     if (modified)
         _current.dirty = true;
 
@@ -4999,6 +5002,15 @@ void HostConnector::hostRemoveInstanceForBlock(const uint8_t row, const uint8_t 
 
 void HostConnector::jsonPresetLoad(Preset& presetdata, const nlohmann::json& jpreset) const
 {
+    // ----------------------------------------------------------------------------------------------------------------
+    // always do cleanup before anything else, for optional values that might not get set
+
+    for (uint8_t s = 0; s < NUM_SCENES_PER_PRESET; ++s)
+    {
+        presetdata.scenes[s].state = HostConnector::kSceneUnused;
+        presetdata.scenes[s].name.clear();
+    }
+
     // ----------------------------------------------------------------------------------------------------------------
     // background
 

--- a/src/connector.cpp
+++ b/src/connector.cpp
@@ -2423,8 +2423,6 @@ void HostConnector::clearAllScenes()
 
     for (uint8_t s = 0; s < NUM_SCENES_PER_PRESET; ++s)
     {
-        if (_current.scenes[s].state == HostConnector::kSceneUnused)
-            continue;
         _current.scenes[s].state = HostConnector::kSceneUnused;
         _current.scenes[s].name.clear();
         modified = true;
@@ -2433,6 +2431,12 @@ void HostConnector::clearAllScenes()
     if (_current.defaultScene != 0)
     {
         _current.defaultScene = 0;
+        modified = true;
+    }
+
+    if (_current.scene != 0)
+    {
+        _current.scene = 0;
         modified = true;
     }
 

--- a/src/connector.cpp
+++ b/src/connector.cpp
@@ -2497,6 +2497,9 @@ bool HostConnector::copyScene(const uint8_t orig, const uint8_t dest)
         _current.scenes[dest].name = _current.scenes[orig].name;
         _current.scenes[dest].state = HostConnector::kSceneInUse;
         copySceneData(orig, dest);
+
+        if (_current.scene == dest)
+            switchScene(dest, true);
     }
     else
     {
@@ -2644,14 +2647,12 @@ void HostConnector::swapScenes(const uint8_t sceneA, const uint8_t sceneB)
 
 // --------------------------------------------------------------------------------------------------------------------
 
-bool HostConnector::switchScene(const uint8_t scene, const bool discardPrevious)
+bool HostConnector::switchScene(const uint8_t scene, const bool switchEvenIfSameScene)
 {
-    mod_log_debug("switchScene(%u, %s)", scene, bool2str(discardPrevious));
+    mod_log_debug("switchScene(%u, %s)", scene, bool2str(switchEvenIfSameScene));
     assert(scene < NUM_SCENES_PER_PRESET);
 
-    // TODO discardPrevious
-
-    if (_current.scene == scene)
+    if (_current.scene == scene && ! switchEvenIfSameScene)
         return false;
 
     // preallocating some data
@@ -2671,12 +2672,11 @@ bool HostConnector::switchScene(const uint8_t scene, const bool discardPrevious)
             _current.dirty = false;
     }
 
+    const bool activateNewScene = _current.scenes[scene].state == kSceneUnused;
     const uint8_t previousScene = _current.scene;
 
     if (_current.scenes[previousScene].state == kSceneInUseTemporarily)
         _current.scenes[previousScene].state = kSceneUnused;
-
-    const bool activateNewScene = _current.scenes[scene].state == kSceneUnused;
 
     _current.scene = scene;
 

--- a/src/connector.cpp
+++ b/src/connector.cpp
@@ -1247,6 +1247,8 @@ void HostConnector::clearCurrentPreset()
 {
     mod_log_debug("clearCurrentPreset()");
 
+    clearAllSceneData();
+
     _current.uuid = generateUUID();
 
     if (_current.numLoadedPlugins == 0)
@@ -1272,7 +1274,6 @@ void HostConnector::clearCurrentPreset()
         _current.bindings[hwid].parameters.clear();
     }
 
-    _current.scene = _current.defaultScene = 0;
     _current.numLoadedPlugins = 0;
     _current.dirty = true;
 
@@ -2419,31 +2420,7 @@ void HostConnector::clearAllScenes()
 {
     mod_log_debug("clearAllScenes()");
 
-    bool modified = false;
-
-    for (uint8_t s = 0; s < NUM_SCENES_PER_PRESET; ++s)
-    {
-        _current.scenes[s].state = HostConnector::kSceneUnused;
-        _current.scenes[s].name.clear();
-        modified = true;
-    }
-
-    if (_current.defaultScene != 0)
-    {
-        _current.defaultScene = 0;
-        modified = true;
-    }
-
-    if (_current.scene != 0)
-    {
-        _current.scene = 0;
-        modified = true;
-    }
-
-    _current.scenes[0].state = HostConnector::kSceneInUse;
-
-    if (modified)
-        _current.dirty = true;
+    clearAllSceneData();
 
     for (uint8_t row = 0; row < NUM_BLOCK_CHAIN_ROWS; ++row)
     {
@@ -6843,6 +6820,39 @@ void HostConnector::enableAudioProcessing(const bool enable)
 void HostConnector::setDirty(const bool dirty)
 {
     _current.dirty = dirty;
+}
+
+// --------------------------------------------------------------------------------------------------------------------
+
+void HostConnector::clearAllSceneData()
+{
+    bool modified = false;
+
+    for (uint8_t s = 0; s < NUM_SCENES_PER_PRESET; ++s)
+    {
+        if (_current.scenes[s].state == HostConnector::kSceneUnused)
+            continue;
+        _current.scenes[s].state = HostConnector::kSceneUnused;
+        _current.scenes[s].name.clear();
+        modified = true;
+    }
+
+    if (_current.defaultScene != 0)
+    {
+        _current.defaultScene = 0;
+        modified = true;
+    }
+
+    if (_current.scene != 0)
+    {
+        _current.scene = 0;
+        modified = true;
+    }
+
+    _current.scenes[0].state = HostConnector::kSceneInUse;
+
+    if (modified)
+        _current.dirty = true;
 }
 
 // --------------------------------------------------------------------------------------------------------------------

--- a/src/connector.cpp
+++ b/src/connector.cpp
@@ -1448,7 +1448,7 @@ bool HostConnector::enableBlock(const uint8_t row, const uint8_t block, const bo
         ParameterBinding& binding = bindings.parameters.front();
 
         if (bindings.parameters.size() == 1 &&
-            (binding.row == row && binding.block == block && binding.parameterSymbol == ":bypass"))
+            (binding.row == row && binding.block == block && binding.meta.isBypass))
         {
             bindings.value = enable ? binding.max : binding.min;
         }
@@ -2830,7 +2830,7 @@ bool HostConnector::switchScene(const uint8_t scene, const bool switchEvenIfSame
 
         for (const ParameterBinding& binding : bindings.parameters)
         {
-            if (binding.parameterSymbol == ":bypass")
+            if (binding.meta.isBypass)
                 continue;
 
             assert(binding.meta.parameterIndex < NUM_BLOCKS_PER_PRESET);
@@ -2854,7 +2854,7 @@ bool HostConnector::switchScene(const uint8_t scene, const bool switchEvenIfSame
             const ParameterBinding& binding = bindings.parameters.front();
             const Block& blockdata = _current.chains[binding.row].blocks[binding.block];
 
-            if (binding.parameterSymbol == ":bypass")
+            if (binding.meta.isBypass)
             {
                 bindings.value = blockdata.enabled ? binding.max : binding.min;
             }
@@ -3033,7 +3033,7 @@ bool HostConnector::editBlockBinding(const uint8_t hwid, const uint8_t row, cons
             continue;
         if (it->block != block)
             continue;
-        if (it->parameterSymbol != ":bypass")
+        if (! it->meta.isBypass)
             continue;
 
         it->min = inverted ? 1.f : 0.f;
@@ -3076,7 +3076,7 @@ bool HostConnector::editBlockParameterBinding(const uint8_t hwid,
             continue;
         if (it->block != block)
             continue;
-        if (it->parameterSymbol == ":bypass")
+        if (it->meta.isBypass)
             continue;
         if (it->meta.parameterIndex != paramIndex)
             continue;
@@ -3159,7 +3159,7 @@ bool HostConnector::removeBlockBinding(const uint8_t hwid, const uint8_t row, co
             continue;
         if (it->block != block)
             continue;
-        if (it->parameterSymbol != ":bypass")
+        if (! it->meta.isBypass)
             continue;
 
         bindings.erase(it);
@@ -3206,7 +3206,7 @@ bool HostConnector::removeBlockParameterBinding(const uint8_t hwid,
             continue;
         if (it->block != block)
             continue;
-        if (it->parameterSymbol == ":bypass")
+        if (it->meta.isBypass)
             continue;
         if (it->meta.parameterIndex != paramIndex)
             continue;
@@ -3272,7 +3272,7 @@ bool HostConnector::replaceBlockBinding(const uint8_t hwid,
             continue;
         if (it->block != block)
             continue;
-        if (it->parameterSymbol != ":bypass")
+        if (! it->meta.isBypass)
             continue;
 
         const float min = it->min;
@@ -3521,7 +3521,7 @@ void HostConnector::setBindingValue(const uint8_t hwid,
             float min = it->min;
             float max = it->max;
 
-            if (it->parameterSymbol == ":bypass")
+            if (it->meta.isBypass)
             {
                 const bool enabled = min > max ? value < 0.5 : value >= 0.5;
                 enableBlock(row, block, enabled, sceneMode);

--- a/src/connector.cpp
+++ b/src/connector.cpp
@@ -2369,6 +2369,8 @@ void HostConnector::renamePreset(const uint8_t preset, const char* const name)
 
 void HostConnector::clearAllScenes()
 {
+    mod_log_debug("clearAllScenes()");
+
     bool modified = false;
 
     for (uint8_t s = 0; s < NUM_SCENES_PER_PRESET; ++s)
@@ -2440,45 +2442,9 @@ bool HostConnector::copyScene(const uint8_t orig, const uint8_t dest)
     }
 
     if (_current.scenes[orig].active)
-    {
-        _current.scenes[dest].active = true;
-        _current.scenes[dest].name = _current.scenes[orig].name;
-
-        for (uint8_t row = 0; row < NUM_BLOCK_CHAIN_ROWS; ++row)
-        {
-            for (uint8_t bl = 0; bl < NUM_BLOCKS_PER_PRESET; ++bl)
-            {
-                Block& blockdata(_current.chains[row].blocks[bl]);
-                if (isNullBlock(blockdata))
-                    continue;
-                if (blockdata.meta.numParametersInScenes == 0)
-                    continue;
-
-                if (blockdata.meta.enable.hasScenes)
-                {
-                    blockdata.scenes.enableValues[dest] = blockdata.scenes.enableValues[orig];
-                    blockdata.scenes.lastSavedEnableValues[dest] = blockdata.scenes.enableValues[orig];
-                }
-
-                for (Parameter& paramdata : blockdata.parameters)
-                {
-                    if (isNullURI(paramdata.symbol))
-                        break;
-                    if ((paramdata.meta.flags & Lv2ParameterNotAllowedToChange) != 0)
-                        continue;
-                    if ((paramdata.meta.flags & Lv2ParameterInScene) == 0)
-                        continue;
-
-                    paramdata.scenes.values[dest] = paramdata.scenes.values[orig];
-                    paramdata.scenes.lastSavedValues[dest] = paramdata.scenes.values[orig];
-                }
-            }
-        }
-    }
+        copySceneData(orig, dest);
     else
-    {
         clearScene(dest);
-    }
 
     _current.dirty = true;
     return true;
@@ -2832,8 +2798,15 @@ bool HostConnector::renameScene(const uint8_t scene, const char* const name)
     if (_current.scenes[scene].name == name)
         return false;
 
+    if (! _current.scenes[scene].active)
+    {
+        if (_current.scenes[_current.scene].active)
+            copySceneData(_current.scene, scene);
+        else
+            _current.scenes[scene].active = true;
+    }
+
     _current.dirty = true;
-    _current.scenes[scene].active = true;
     _current.scenes[scene].name = name;
     return true;
 }
@@ -6731,6 +6704,47 @@ void HostConnector::setDirty(const bool dirty)
 }
 
 // --------------------------------------------------------------------------------------------------------------------
+
+void HostConnector::copySceneData(uint8_t orig, uint8_t dest)
+{
+    assert(orig < NUM_SCENES_PER_PRESET);
+    assert(dest < NUM_SCENES_PER_PRESET);
+    assert(_current.scenes[orig].active);
+
+    _current.scenes[dest].active = true;
+    _current.scenes[dest].name = _current.scenes[orig].name;
+
+    for (uint8_t row = 0; row < NUM_BLOCK_CHAIN_ROWS; ++row)
+    {
+        for (uint8_t bl = 0; bl < NUM_BLOCKS_PER_PRESET; ++bl)
+        {
+            Block& blockdata(_current.chains[row].blocks[bl]);
+            if (isNullBlock(blockdata))
+                continue;
+            if (blockdata.meta.numParametersInScenes == 0)
+                continue;
+
+            if (blockdata.meta.enable.hasScenes)
+            {
+                blockdata.scenes.enableValues[dest] = blockdata.scenes.enableValues[orig];
+                blockdata.scenes.lastSavedEnableValues[dest] = blockdata.scenes.enableValues[orig];
+            }
+
+            for (Parameter& paramdata : blockdata.parameters)
+            {
+                if (isNullURI(paramdata.symbol))
+                    break;
+                if ((paramdata.meta.flags & Lv2ParameterNotAllowedToChange) != 0)
+                    continue;
+                if ((paramdata.meta.flags & Lv2ParameterInScene) == 0)
+                    continue;
+
+                paramdata.scenes.values[dest] = paramdata.scenes.values[orig];
+                paramdata.scenes.lastSavedValues[dest] = paramdata.scenes.values[orig];
+            }
+        }
+    }
+}
 
 void HostConnector::initBlock(HostConnector::Block& blockdata,
                               const std::shared_ptr<const Lv2Plugin>& plugin,

--- a/src/connector.cpp
+++ b/src/connector.cpp
@@ -2406,17 +2406,7 @@ void HostConnector::renamePreset(const uint8_t preset, const char* const name)
 
     nlohmann::json j;
     if (! loadPresetFromFile(filename.c_str(), j))
-    {
-        try {
-            j = {};
-            j["version"] = JSON_PRESET_VERSION_CURRENT;
-            j["type"] = "preset";
-            j["preset"] = nlohmann::json::object({});
-        } catch (...) {
-            return;
-        }
-        jsonPresetSave(_presets[preset], j["preset"]);
-    }
+        return;
 
     j["name"] = name;
     safeJsonSave(j, filename);

--- a/src/connector.cpp
+++ b/src/connector.cpp
@@ -2707,7 +2707,7 @@ bool HostConnector::switchScene(const uint8_t scene, const bool switchEvenIfSame
 
     if (activateNewScene)
     {
-        _current.scenes[scene].name = _current.scenes[previousScene].name;
+        _current.scenes[scene].name.clear();
         _current.scenes[scene].state = kSceneInUseTemporarily;
     }
 

--- a/src/connector.cpp
+++ b/src/connector.cpp
@@ -2407,7 +2407,7 @@ void HostConnector::clearAllScenes()
 
     for (uint8_t s = 0; s < NUM_SCENES_PER_PRESET; ++s)
     {
-        if (_current.scenes[s].state != HostConnector::kSceneUnused)
+        if (_current.scenes[s].state == HostConnector::kSceneUnused)
             continue;
         _current.scenes[s].state = HostConnector::kSceneUnused;
         _current.scenes[s].name.clear();

--- a/src/connector.cpp
+++ b/src/connector.cpp
@@ -443,7 +443,7 @@ void HostConnector::Preset::copy(const Preset& other)
     for (uint8_t i = 0; i < NUM_BINDING_ACTUATORS; ++i)
         bindings[i].copy(other.bindings[i]);
     background = other.background;
-    sceneNames = other.sceneNames;
+    scenes = other.scenes;
     uuid = other.uuid;
     chains = other.chains;
 }
@@ -2367,6 +2367,125 @@ void HostConnector::renamePreset(const uint8_t preset, const char* const name)
 
 // --------------------------------------------------------------------------------------------------------------------
 
+void HostConnector::clearAllScenes()
+{
+    bool modified = false;
+
+    for (uint8_t s = 0; s < NUM_SCENES_PER_PRESET; ++s)
+    {
+        if (_current.scenes[s].active)
+            continue;
+        _current.scenes[s].active = false;
+        _current.scenes[s].name.clear();
+        modified = true;
+    }
+
+    if (modified)
+        _current.dirty = true;
+
+    for (uint8_t row = 0; row < NUM_BLOCK_CHAIN_ROWS; ++row)
+    {
+        for (uint8_t bl = 0; bl < NUM_BLOCKS_PER_PRESET; ++bl)
+        {
+            Block& blockdata(_current.chains[row].blocks[bl]);
+            if (isNullBlock(blockdata))
+                continue;
+
+            blockdata.meta.enable.hasScenes = false;
+            blockdata.meta.enable.tempSceneState = kTemporarySceneNone;
+            blockdata.meta.numParametersInScenes = 0;
+
+            for (Parameter& paramdata : blockdata.parameters)
+            {
+                if (isNullURI(paramdata.symbol))
+                    break;
+                if ((paramdata.meta.flags & Lv2ParameterNotAllowedToChange) != 0)
+                    continue;
+
+                paramdata.meta.flags &= ~Lv2ParameterInScene;
+                paramdata.meta.tempSceneState = kTemporarySceneNone;
+            }
+        }
+    }
+}
+
+// --------------------------------------------------------------------------------------------------------------------
+
+void HostConnector::clearScene(const uint8_t scene)
+{
+    mod_log_debug("clearScene(%u)", scene);
+    assert(scene < NUM_SCENES_PER_PRESET);
+
+    if (! _current.scenes[scene].active)
+        return;
+
+    _current.scenes[scene].active = false;
+    _current.scenes[scene].name.clear();
+
+    _current.dirty = true;
+}
+
+// --------------------------------------------------------------------------------------------------------------------
+
+bool HostConnector::copyScene(const uint8_t orig, const uint8_t dest)
+{
+    mod_log_debug("reorderScenes(%u, %u)", orig, dest);
+    assert(orig < NUM_SCENES_PER_PRESET);
+    assert(dest < NUM_SCENES_PER_PRESET);
+
+    if (orig == dest)
+    {
+        mod_log_warn("reorderScenes(%u, %u) - orig == dest, rejected", orig, dest);
+        return false;
+    }
+
+    if (_current.scenes[orig].active)
+    {
+        _current.scenes[dest].active = true;
+        _current.scenes[dest].name = _current.scenes[orig].name;
+
+        for (uint8_t row = 0; row < NUM_BLOCK_CHAIN_ROWS; ++row)
+        {
+            for (uint8_t bl = 0; bl < NUM_BLOCKS_PER_PRESET; ++bl)
+            {
+                Block& blockdata(_current.chains[row].blocks[bl]);
+                if (isNullBlock(blockdata))
+                    continue;
+                if (blockdata.meta.numParametersInScenes == 0)
+                    continue;
+
+                if (blockdata.meta.enable.hasScenes)
+                {
+                    blockdata.scenes.enableValues[dest] = blockdata.scenes.enableValues[orig];
+                    blockdata.scenes.lastSavedEnableValues[dest] = blockdata.scenes.enableValues[orig];
+                }
+
+                for (Parameter& paramdata : blockdata.parameters)
+                {
+                    if (isNullURI(paramdata.symbol))
+                        break;
+                    if ((paramdata.meta.flags & Lv2ParameterNotAllowedToChange) != 0)
+                        continue;
+                    if ((paramdata.meta.flags & Lv2ParameterInScene) == 0)
+                        continue;
+
+                    paramdata.scenes.values[dest] = paramdata.scenes.values[orig];
+                    paramdata.scenes.lastSavedValues[dest] = paramdata.scenes.values[orig];
+                }
+            }
+        }
+    }
+    else
+    {
+        clearScene(dest);
+    }
+
+    _current.dirty = true;
+    return true;
+}
+
+// --------------------------------------------------------------------------------------------------------------------
+
 // std::vector<bool> cannot swap values directly, give it a little hand...
 static void vector_bool_swap(std::vector<bool>& vector, uint8_t a, uint8_t b)
 {
@@ -2404,7 +2523,7 @@ bool HostConnector::reorderScenes(const uint8_t orig, const uint8_t dest)
             }
         }
 
-        std::swap(_current.sceneNames[sceneA], _current.sceneNames[sceneB]);
+        std::swap(_current.scenes[sceneA], _current.scenes[sceneB]);
     };
 
     // moving preset backwards to the left
@@ -2482,7 +2601,7 @@ void HostConnector::swapScenes(const uint8_t sceneA, const uint8_t sceneB)
         }
     }
 
-    std::swap(_current.sceneNames[sceneA], _current.sceneNames[sceneB]);
+    std::swap(_current.scenes[sceneA], _current.scenes[sceneB]);
 
     // adjust data for current scene, if matching
     if (_current.scene == sceneA)
@@ -2502,10 +2621,12 @@ void HostConnector::swapScenes(const uint8_t sceneA, const uint8_t sceneB)
 
 // --------------------------------------------------------------------------------------------------------------------
 
-bool HostConnector::switchScene(const uint8_t scene)
+bool HostConnector::switchScene(const uint8_t scene, const bool discardPrevious)
 {
-    mod_log_debug("switchScene(%u)", scene);
+    mod_log_debug("switchScene(%u, %s)", scene, bool2str(discardPrevious));
     assert(scene < NUM_SCENES_PER_PRESET);
+
+    // TODO discardPrevious
 
     if (_current.scene == scene)
         return false;
@@ -2528,7 +2649,16 @@ bool HostConnector::switchScene(const uint8_t scene)
     }
 
     const uint8_t previousScene = _current.scene;
+    const bool previousSceneWasActive =_current.scenes[previousScene].active;
+    const bool activateNewScene = !_current.scenes[scene].active;
+
     _current.scene = scene;
+
+    if (activateNewScene)
+    {
+        _current.scenes[scene].active = true;
+        _current.scenes[scene].name = _current.scenes[previousScene].name;
+    }
 
     const Host::NonBlockingScope hnbs(_host);
 
@@ -2546,7 +2676,9 @@ bool HostConnector::switchScene(const uint8_t scene)
 
             params.clear();
 
-            const bool blockEnabled = blockdata.scenes.lastSavedEnableValues[scene];
+            const bool blockEnabled = previousSceneWasActive
+                                    ? blockdata.scenes.lastSavedEnableValues[previousScene]
+                                    : blockdata.enabled;
 
             // revert temp scene state
             switch (blockdata.meta.enable.tempSceneState)
@@ -2558,14 +2690,14 @@ bool HostConnector::switchScene(const uint8_t scene)
                 --blockdata.meta.numParametersInScenes;
                 blockdata.meta.enable.hasScenes = false;
                 blockdata.meta.enable.tempSceneState = kTemporarySceneNone;
-                blockdata.scenes.enableValues[previousScene] = blockdata.scenes.lastSavedEnableValues[previousScene];
+                blockdata.scenes.enableValues[previousScene] = blockEnabled;
                 break;
             case kTemporarySceneClear:
                 assert(!blockdata.meta.enable.hasScenes);
                 ++blockdata.meta.numParametersInScenes;
                 blockdata.meta.enable.hasScenes = true;
                 blockdata.meta.enable.tempSceneState = kTemporarySceneNone;
-                blockdata.scenes.enableValues[previousScene] = blockdata.scenes.lastSavedEnableValues[previousScene];
+                blockdata.scenes.enableValues[previousScene] = blockEnabled;
                 break;
             }
 
@@ -2583,6 +2715,10 @@ bool HostConnector::switchScene(const uint8_t scene)
                 if ((paramdata.meta.flags & Lv2ParameterNotAllowedInScenes) != 0)
                     continue;
 
+                const float value = previousSceneWasActive
+                                  ? paramdata.scenes.lastSavedValues[previousScene]
+                                  : paramdata.value;
+
                 // revert temp scene state
                 switch (paramdata.meta.tempSceneState)
                 {
@@ -2593,22 +2729,25 @@ bool HostConnector::switchScene(const uint8_t scene)
                     --blockdata.meta.numParametersInScenes;
                     paramdata.meta.flags &= ~Lv2ParameterInScene;
                     paramdata.meta.tempSceneState = kTemporarySceneNone;
-                    paramdata.scenes.values[previousScene] = paramdata.scenes.lastSavedValues[previousScene];
+                    paramdata.scenes.values[previousScene] = value;
                     break;
                 case kTemporarySceneClear:
                     assert((paramdata.meta.flags & Lv2ParameterInScene) == 0);
                     ++blockdata.meta.numParametersInScenes;
                     paramdata.meta.flags |= Lv2ParameterInScene;
                     paramdata.meta.tempSceneState = kTemporarySceneNone;
-                    paramdata.scenes.values[previousScene] = paramdata.scenes.lastSavedValues[previousScene];
+                    paramdata.scenes.values[previousScene] = value;
                     break;
                 }
 
-                if (isNotEqual(paramdata.value, paramdata.scenes.lastSavedValues[scene]))
+                if (isNotEqual(paramdata.value, value))
                 {
-                    paramdata.value = paramdata.scenes.lastSavedValues[scene];
+                    paramdata.value = value;
                     params.push_back({ paramdata.symbol.c_str(), paramdata.value });
                 }
+
+                if (activateNewScene)
+                    paramdata.scenes.values[scene] = paramdata.scenes.lastSavedValues[scene] = value;
             }
 
             hostParamsFlushBlockPair(hbp, LV2_KXSTUDIO_PROPERTIES_RESET_NONE, params);
@@ -2619,6 +2758,9 @@ bool HostConnector::switchScene(const uint8_t scene)
                 blockdata.enabled = true;
                 hostBypassBlockPair(hbp, false);
             }
+
+            if (activateNewScene)
+                blockdata.scenes.enableValues[scene] = blockdata.scenes.enableValues[scene] = blockEnabled;
         }
     }
 
@@ -2687,11 +2829,12 @@ bool HostConnector::renameScene(const uint8_t scene, const char* const name)
     assert(scene < NUM_SCENES_PER_PRESET);
     assert(name != nullptr);
 
-    if (_current.sceneNames[scene] == name)
+    if (_current.scenes[scene].name == name)
         return false;
 
     _current.dirty = true;
-    _current.sceneNames[scene] = name;
+    _current.scenes[scene].active = true;
+    _current.scenes[scene].name = name;
     return true;
 }
 
@@ -5481,37 +5624,38 @@ void HostConnector::jsonPresetLoad(Preset& presetdata, const nlohmann::json& jpr
     // ----------------------------------------------------------------------------------------------------------------
     // sceneNames
 
-    if (jpreset.contains("sceneNames"))
-    {
-        const auto& jsceneNames = jpreset["sceneNames"];
-        std::string name;
-
-        for (uint8_t s = 0; s < NUM_SCENES_PER_PRESET; ++s)
-        {
-            const std::string jsceneid = std::to_string(s + 1);
-
-            if (jsceneNames.contains(jsceneid))
-            {
-                try {
-                    name = jsceneNames[jsceneid].get<std::string>();
-                } catch (...) {
-                    mod_log_warn("jsonPresetLoad(): preset contains invalid scene name");
-                    name.clear();
-                }
-
-                presetdata.sceneNames[s] = name;
-            }
-            else
-            {
-                presetdata.sceneNames[s].clear();
-            }
-        }
-    }
-    else
-    {
-        for (uint8_t s = 0; s < NUM_SCENES_PER_PRESET; ++s)
-            presetdata.sceneNames[s].clear();
-    }
+    // TODO
+    // if (jpreset.contains("sceneNames"))
+    // {
+    //     const auto& jsceneNames = jpreset["sceneNames"];
+    //     std::string name;
+    //
+    //     for (uint8_t s = 0; s < NUM_SCENES_PER_PRESET; ++s)
+    //     {
+    //         const std::string jsceneid = std::to_string(s + 1);
+    //
+    //         if (jsceneNames.contains(jsceneid))
+    //         {
+    //             try {
+    //                 name = jsceneNames[jsceneid].get<std::string>();
+    //             } catch (...) {
+    //                 mod_log_warn("jsonPresetLoad(): preset contains invalid scene name");
+    //                 name.clear();
+    //             }
+    //
+    //             presetdata.sceneNames[s] = name;
+    //         }
+    //         else
+    //         {
+    //             presetdata.sceneNames[s].clear();
+    //         }
+    //     }
+    // }
+    // else
+    // {
+    //     for (uint8_t s = 0; s < NUM_SCENES_PER_PRESET; ++s)
+    //         presetdata.sceneNames[s].clear();
+    // }
 
     // ----------------------------------------------------------------------------------------------------------------
     // uuid
@@ -5721,19 +5865,20 @@ void HostConnector::jsonPresetSave(const Preset& presetdata, nlohmann::json& jpr
     // ----------------------------------------------------------------------------------------------------------------
     // sceneNames
 
-    for (const std::string& sceneName : presetdata.sceneNames)
-    {
-        if (sceneName.empty())
-            continue;
-
-        auto& jsceneNames = jpreset["sceneNames"] = nlohmann::json::object({});
-        for (uint8_t s = 0; s < NUM_SCENES_PER_PRESET; ++s)
-        {
-            const std::string jsceneid = std::to_string(s + 1);
-            jsceneNames[jsceneid] = presetdata.sceneNames[s];
-        }
-        break;
-    }
+    // TODO
+    // for (const std::string& sceneName : presetdata.sceneNames)
+    // {
+    //     if (sceneName.empty())
+    //         continue;
+    //
+    //     auto& jsceneNames = jpreset["sceneNames"] = nlohmann::json::object({});
+    //     for (uint8_t s = 0; s < NUM_SCENES_PER_PRESET; ++s)
+    //     {
+    //         const std::string jsceneid = std::to_string(s + 1);
+    //         jsceneNames[jsceneid] = presetdata.sceneNames[s];
+    //     }
+    //     break;
+    // }
 }
 
 // --------------------------------------------------------------------------------------------------------------------
@@ -6887,7 +7032,10 @@ void HostConnector::resetPreset(Preset& preset)
     }
 
     for (uint8_t s = 0; s < NUM_SCENES_PER_PRESET; ++s)
-        preset.sceneNames[s].clear();
+    {
+        preset.scenes[s].active = false;
+        preset.scenes[s].name.clear();
+    }
 }
 
 void HostConnector::resetPresetPorts(Preset& preset, const bool usingDefault)

--- a/src/connector.cpp
+++ b/src/connector.cpp
@@ -2647,9 +2647,9 @@ void HostConnector::swapScenes(const uint8_t sceneA, const uint8_t sceneB)
 
 // --------------------------------------------------------------------------------------------------------------------
 
-bool HostConnector::switchScene(const uint8_t scene, const bool switchEvenIfSameScene)
+bool HostConnector::switchScene(const uint8_t scene, const bool switchEvenIfSameScene, const bool discardIfUnused)
 {
-    mod_log_debug("switchScene(%u, %s)", scene, bool2str(switchEvenIfSameScene));
+    mod_log_debug("switchScene(%u, %s, %s)", scene, bool2str(switchEvenIfSameScene), bool2str(discardIfUnused));
     assert(scene < NUM_SCENES_PER_PRESET);
 
     if (_current.scene == scene && ! switchEvenIfSameScene)
@@ -2676,7 +2676,7 @@ bool HostConnector::switchScene(const uint8_t scene, const bool switchEvenIfSame
     const uint8_t previousScene = _current.scene;
 
     if (_current.scenes[previousScene].state == kSceneInUseTemporarily)
-        _current.scenes[previousScene].state = kSceneUnused;
+        _current.scenes[previousScene].state = discardIfUnused ? kSceneUnused : kSceneInUse;
 
     _current.scene = scene;
 
@@ -2727,7 +2727,7 @@ bool HostConnector::switchScene(const uint8_t scene, const bool switchEvenIfSame
             }
 
             blockEnabled = activateNewScene || !blockdata.meta.enable.hasScenes
-                         ? blockdata.enabled
+                         ? blockdata.scenes.lastSavedEnableValues[_current.defaultScene]
                          : blockdata.scenes.enableValues[scene];
 
             // bypass/disable first if relevant
@@ -2766,7 +2766,7 @@ bool HostConnector::switchScene(const uint8_t scene, const bool switchEvenIfSame
                 }
 
                 paramValue = activateNewScene || (paramdata.meta.flags & Lv2ParameterInScene) == 0
-                           ? paramdata.value
+                           ? paramdata.scenes.lastSavedValues[_current.defaultScene]
                            : paramdata.scenes.values[scene];
 
                 if (isNotEqual(paramdata.value, paramValue))
@@ -7141,7 +7141,10 @@ void HostConnector::resetPreset(Preset& preset)
         preset.bindings[hwid].value = 0.0;
     }
 
-    for (uint8_t s = 0; s < NUM_SCENES_PER_PRESET; ++s)
+    preset.scenes[0].state = HostConnector::kSceneInUse;
+    preset.scenes[0].name.clear();
+
+    for (uint8_t s = 1; s < NUM_SCENES_PER_PRESET; ++s)
     {
         preset.scenes[s].state = HostConnector::kSceneUnused;
         preset.scenes[s].name.clear();

--- a/src/connector.cpp
+++ b/src/connector.cpp
@@ -2397,7 +2397,17 @@ void HostConnector::renamePreset(const uint8_t preset, const char* const name)
 
     nlohmann::json j;
     if (! loadPresetFromFile(filename.c_str(), j))
-        return;
+    {
+        try {
+            j = {};
+            j["version"] = JSON_PRESET_VERSION_CURRENT;
+            j["type"] = "preset";
+            j["preset"] = nlohmann::json::object({});
+        } catch (...) {
+            return;
+        }
+        jsonPresetSave(_presets[preset], j["preset"]);
+    }
 
     j["name"] = name;
     safeJsonSave(j, filename);

--- a/src/connector.cpp
+++ b/src/connector.cpp
@@ -3687,6 +3687,27 @@ void HostConnector::waitAudioCycle()
 
 // --------------------------------------------------------------------------------------------------------------------
 
+std::string HostConnector::serializeCurrentPreset() const
+{
+    nlohmann::json j;
+    jsonPresetSave(_current, j);
+
+    // from Current
+    j["defaultScene"] = _current.defaultScene;
+    j["preset"] = _current.preset;
+    j["numLoadedPlugins"] = _current.numLoadedPlugins;
+    j["dirty"] = _current.dirty;
+
+    // from Preset, not saved to json file
+    j["filename"] = _current.filename;
+
+    // TODO more fields
+
+    return j.dump(-1, ' ', false, nlohmann::detail::error_handler_t::replace);
+}
+
+// --------------------------------------------------------------------------------------------------------------------
+
 void HostConnector::enableCpuLoadUpdates(const bool enable)
 {
     _host.feature_enable(Host::kFeatureCpuLoad, enable ? 1 : 0);

--- a/src/connector.hpp
+++ b/src/connector.hpp
@@ -693,7 +693,7 @@ public:
 
     // switch to another scene, which automatically activates it
     // returning false means the current chain was unchanged
-    bool switchScene(uint8_t scene, bool discardPrevious = false);
+    bool switchScene(uint8_t scene, bool switchEvenIfSameScene = false);
 
     // rename a scene
     bool renameScene(uint8_t scene, const char* name);

--- a/src/connector.hpp
+++ b/src/connector.hpp
@@ -10,6 +10,7 @@
 
 #include <cassert>
 #include <cstdint>
+#include <algorithm>
 #include <array>
 #include <list>
 #include <unordered_map>
@@ -1042,21 +1043,22 @@ static inline constexpr bool hasScenes(const HostBlock& block)
 
 static inline bool hasScenes(const HostBindings& bindings)
 {
-    for (const HostParameterBinding &binding : bindings.parameters)
-    {
-        if (binding.meta.isBypass)
+    return std::any_of(bindings.parameters.cbegin(),
+                       bindings.parameters.cend(),
+                       [](const HostParameterBinding &binding)
         {
-            if (hasScenes(binding.meta.block))
-                return true;
-        }
-        else
-        {
-            if (hasScenes(binding.meta.parameter))
-                return true;
-        }
-    }
-
-    return false;
+            if (binding.meta.isBypass)
+            {
+                if (hasScenes(binding.meta.block))
+                    return true;
+            }
+            else
+            {
+                if (hasScenes(binding.meta.parameter))
+                    return true;
+            }
+            return false;
+        });
 }
 
 // --------------------------------------------------------------------------------------------------------------------

--- a/src/connector.hpp
+++ b/src/connector.hpp
@@ -530,6 +530,11 @@ public:
     void printStateForDebug(bool withBlocks, bool withParams, bool withBindings) const;
 
     // ----------------------------------------------------------------------------------------------------------------
+    // wasm helpers
+
+    [[nodiscard]] std::string serializeCurrentPreset() const;
+
+    // ----------------------------------------------------------------------------------------------------------------
     // cpu load handling
 
     void enableCpuLoadUpdates(bool enable);

--- a/src/connector.hpp
+++ b/src/connector.hpp
@@ -1045,7 +1045,10 @@ static inline constexpr bool hasScenes(const HostParameter& param)
 
 static inline constexpr bool hasScenes(const HostBlock& block)
 {
-    return block.meta.enable.hasScenes;
+    return block.meta.enable.hasScenes ||
+        std::any_of(block.parameters.cbegin(),
+                    block.parameters.cend(),
+                    [](const HostParameter &param) { return hasScenes(param); });
 }
 
 static inline bool hasScenes(const HostBindings& bindings)

--- a/src/connector.hpp
+++ b/src/connector.hpp
@@ -465,6 +465,9 @@ public:
     // set callback used for disconnect and feedback events
     void setCallback(Callback* callback);
 
+    // disconnect from host so an alternative remote can take over
+    void disconnect();
+
     // try to reconnect host if it previously failed
     bool reconnect();
 

--- a/src/connector.hpp
+++ b/src/connector.hpp
@@ -693,7 +693,7 @@ public:
 
     // switch to another scene, which automatically activates it
     // returning false means the current chain was unchanged
-    bool switchScene(uint8_t scene, bool switchEvenIfSameScene = false);
+    bool switchScene(uint8_t scene, bool switchEvenIfSameScene = false, bool discardIfUnused = true);
 
     // rename a scene
     bool renameScene(uint8_t scene, const char* name);

--- a/src/connector.hpp
+++ b/src/connector.hpp
@@ -216,7 +216,7 @@ struct HostConnector : Host::Callback {
         kSceneUnused = 0,
         // scene has been enabled temporarily
         // state will change to kSceneInUse if preset is saved
-        // data will be discarded if current/active scene changes without saving first
+        // data can be discarded if current/active scene changes without saving first (see `switchScene`)
         kSceneInUseTemporarily,
         // scene is in use
         kSceneInUse,

--- a/src/connector.hpp
+++ b/src/connector.hpp
@@ -1015,6 +1015,9 @@ private:
     // internal feedback handling, for updating parameter values
     void hostFeedbackCallback(const HostFeedbackData& data) override;
 
+    // internal scene data clear
+    void clearAllSceneData();
+
     // internal scene data copy, orig must be active
     // NOTE does not modify dest scene `name` and `state`
     void copySceneData(uint8_t orig, uint8_t dest);

--- a/src/connector.hpp
+++ b/src/connector.hpp
@@ -645,7 +645,7 @@ public:
    #endif
 
     // ----------------------------------------------------------------------------------------------------------------
-    // scene handling
+    // scene handling (within the current preset)
 
     // clear/delete all scenes
     void clearAllScenes();
@@ -653,20 +653,20 @@ public:
     // clear/delete a specific scene
     void clearScene(uint8_t scene);
 
-    // copy the contents of a scene into a new position (within the current preset)
+    // copy the contents of a scene into a new position
     bool copyScene(uint8_t orig, uint8_t dest);
 
-    // reorder/move a scene into a new position (within the current preset)
+    // reorder/move a scene into a new position
     bool reorderScenes(uint8_t orig, uint8_t dest);
 
-    // swap 2 scenes within the current preset
+    // swap 2 scenes
     void swapScenes(uint8_t sceneA, uint8_t sceneB);
 
-    // switch to another scene within the current preset
+    // switch to another scene, which automatically activates it
     // returning false means the current chain was unchanged
     bool switchScene(uint8_t scene, bool discardPrevious = false);
 
-    // rename a scene within the current preset
+    // rename a scene
     bool renameScene(uint8_t scene, const char* name);
 
     // convenience call for renaming current scene name
@@ -996,6 +996,9 @@ private:
 
     // internal feedback handling, for updating parameter values
     void hostFeedbackCallback(const HostFeedbackData& data) override;
+
+    // internal scene data copy, orig must be active
+    void copySceneData(uint8_t orig, uint8_t dest);
 
     // init block using plugin default values, optionally fill index maps
     void initBlock(Block& blockdata,

--- a/src/connector.hpp
+++ b/src/connector.hpp
@@ -184,9 +184,44 @@ struct HostConnector : Host::Callback {
         virtual void hostDisconnectedCallback() = 0;
     };
 
+    // scene operation mode that applies to parameter changes
+    // if a temporary mode was selected and then reverted, parameters revert to their `lastSavedValues`
+    enum SceneMode {
+        // enable scenes if not active yet
+        kSceneModeActivate,
+        // sync all parameter values in a scene, same as clearing it
+        kSceneModeClear,
+        // only update value, do not activate any scenes
+        kSceneModeUpdate,
+        // enable scenes if not active yet, but only temporarily
+        // scene value is discarded if preset is not saved
+        kSceneModeActivateTemporarily,
+        // sync all parameter values in a scene, same as clearing it, but only temporarily
+        // scene value is "uncleared" if preset is not saved
+        kSceneModeClearTemporarily,
+        // only update value, do not activate any scenes, but only temporarily
+        // scene value is discarded if preset is not saved
+        kSceneModeUpdateTemporarily,
+    };
+
+    enum SceneState : uint8_t {
+        // scene is not in use
+        kSceneUnused = 0,
+        // scene has been enabled temporarily
+        // state will change to kSceneInUse if preset is saved
+        // data will be discarded if current/active scene changes without saving first
+        kSceneInUseTemporarily,
+        // scene is in use
+        kSceneInUse,
+    };
+
+    // temporary scene state that applies to parameter changes
     enum TemporarySceneState : uint8_t {
+        // this parameter has no temporary scene state
         kTemporarySceneNone = 0,
+        // temporarily activate scene for a parameter, becoming part of scenes if saved
         kTemporarySceneActivate,
+        // temporarily clear scene for a parameter, clearing to be completed if saved
         kTemporarySceneClear,
     };
 
@@ -229,24 +264,6 @@ struct HostConnector : Host::Callback {
             CLASS_ONLY_MOVE_INIT_NO_COPY(Meta)
         } meta;
         CLASS_ONLY_MOVE_INIT_NO_COPY(Property)
-    };
-
-    enum SceneMode {
-        // enable scenes if not active yet
-        SceneModeActivate,
-        // sync all parameter values in a scene, same as clearing it
-        SceneModeClear,
-        // only update value, do not activate any scenes
-        SceneModeUpdate,
-        // enable scenes if not active yet, but only temporarily
-        // scene value is discarded if preset is not saved
-        SceneModeActivateTemporarily,
-        // sync all parameter values in a scene, same as clearing it, but only temporarily
-        // scene value is "uncleared" if preset is not saved
-        SceneModeClearTemporarily,
-        // only update value, do not activate any scenes, but only temporarily
-        // scene value is discarded if preset is not saved
-        SceneModeUpdateTemporarily,
     };
 
     struct Block {
@@ -346,7 +363,7 @@ struct HostConnector : Host::Callback {
 
     struct Scene {
         std::string name;
-        bool active;
+        SceneState state;
     };
 
     struct ChainRow {
@@ -760,7 +777,7 @@ public:
                            uint8_t block,
                            uint8_t paramIndex,
                            float value,
-                           SceneMode sceneMode = SceneModeClear);
+                           SceneMode sceneMode = kSceneModeClear);
 
     // set a block parameter value, based on port symbol
     // NOTE value must already be sanitized!
@@ -768,7 +785,7 @@ public:
                            uint8_t block,
                            const char* symbol,
                            float value,
-                           SceneMode sceneMode = SceneModeClear);
+                           SceneMode sceneMode = kSceneModeClear);
 
     // set a block quickpot
     void setBlockQuickPot(uint8_t row, uint8_t block, uint8_t paramIndex);
@@ -871,27 +888,16 @@ public:
     // WIP details below this point
 
     // set a block property, based on property index
-    void setBlockProperty(uint8_t row,
-                          uint8_t block,
-                          uint8_t propIndex,
-                          const char* value,
-                          SceneMode sceneMode = SceneModeClear);
+    void setBlockProperty(uint8_t row, uint8_t block, uint8_t propIndex, const char* value);
 
     // set a block property, based on property URI
-    void setBlockProperty(uint8_t row,
-                          uint8_t block,
-                          const char* uri,
-                          const char* value,
-                          SceneMode sceneMode = SceneModeClear);
+    void setBlockProperty(uint8_t row, uint8_t block, const char* uri, const char* value);
 
     // convenience calls for single-chain builds
    #if NUM_BLOCK_CHAIN_ROWS == 1
-    inline void setBlockProperty(const uint8_t block,
-                                 const uint8_t propIndex,
-                                 const char* const value,
-                                 const SceneMode sceneMode)
+    inline void setBlockProperty(const uint8_t block, const uint8_t propIndex, const char* const value)
     {
-        setBlockProperty(0, block, propIndex, value, sceneMode);
+        setBlockProperty(0, block, propIndex, value);
     }
    #endif
 
@@ -999,6 +1005,7 @@ private:
     void hostFeedbackCallback(const HostFeedbackData& data) override;
 
     // internal scene data copy, orig must be active
+    // NOTE does not modify dest scene `name` and `state`
     void copySceneData(uint8_t orig, uint8_t dest);
 
     // init block using plugin default values, optionally fill index maps

--- a/src/connector.hpp
+++ b/src/connector.hpp
@@ -343,6 +343,11 @@ struct HostConnector : Host::Callback {
         CLASS_ONLY_MOVE_INIT_NO_COPY(Bindings)
     };
 
+    struct Scene {
+        std::string name;
+        bool active;
+    };
+
     struct ChainRow {
         heap_array<Block, NUM_BLOCKS_PER_PRESET> blocks;
         std::array<std::string, 2> capture;
@@ -361,7 +366,7 @@ struct HostConnector : Host::Callback {
             uint32_t color;
             std::string style;
         } background;
-        heap_array<std::string, NUM_SCENES_PER_PRESET> sceneNames;
+        heap_array<Scene, NUM_SCENES_PER_PRESET> scenes;
         std::array<unsigned char, UUID_SIZE> uuid;
     private:
         friend struct HostConnector;
@@ -642,6 +647,15 @@ public:
     // ----------------------------------------------------------------------------------------------------------------
     // scene handling
 
+    // clear/delete all scenes
+    void clearAllScenes();
+
+    // clear/delete a specific scene
+    void clearScene(uint8_t scene);
+
+    // copy the contents of a scene into a new position (within the current preset)
+    bool copyScene(uint8_t orig, uint8_t dest);
+
     // reorder/move a scene into a new position (within the current preset)
     bool reorderScenes(uint8_t orig, uint8_t dest);
 
@@ -650,7 +664,7 @@ public:
 
     // switch to another scene within the current preset
     // returning false means the current chain was unchanged
-    bool switchScene(uint8_t scene);
+    bool switchScene(uint8_t scene, bool discardPrevious = false);
 
     // rename a scene within the current preset
     bool renameScene(uint8_t scene, const char* name);
@@ -1005,6 +1019,7 @@ using HostBlock = HostConnector::Block;
 using HostParameter = HostConnector::Parameter;
 using HostParameterBinding = HostConnector::ParameterBinding;
 using HostProperty = HostConnector::Property;
+using HostScene = HostConnector::Scene;
 using HostSceneMode = HostConnector::SceneMode;
 using HostCallbackData = HostConnector::Callback::Data;
 using HostNonBlockingScope = HostConnector::NonBlockingScope;

--- a/src/connector.hpp
+++ b/src/connector.hpp
@@ -1049,17 +1049,14 @@ using HostNonBlockingScopeWithAudioFades = HostConnector::NonBlockingScopeWithAu
 
 // --------------------------------------------------------------------------------------------------------------------
 
-static inline constexpr bool hasScenes(const HostParameter& param)
+inline constexpr bool hasScenes(const HostParameter& param)
 {
     return (param.meta.flags & Lv2ParameterInScene) != 0;
 }
 
-static inline constexpr bool hasScenes(const HostBlock& block)
+inline constexpr bool hasScenes(const HostBlock& block)
 {
-    return block.meta.enable.hasScenes ||
-        std::any_of(block.parameters.cbegin(),
-                    block.parameters.cend(),
-                    [](const HostParameter &param) { return hasScenes(param); });
+    return block.meta.numParametersInScenes != 0;
 }
 
 static inline bool hasScenes(const HostBindings& bindings)

--- a/src/host.cpp
+++ b/src/host.cpp
@@ -167,13 +167,13 @@ struct Host::Impl
         {
             ipc.reset(IPC::createDualSocketIPC(portNumber));
         }
+       #ifdef __EMSCRIPTEN__
         else
         {
             ipc->last_error.clear();
-           #ifdef __EMSCRIPTEN__
             ipc->reconnect();
-           #endif
         }
+       #endif
 
         last_error = ipc->last_error;
 

--- a/src/host.cpp
+++ b/src/host.cpp
@@ -165,15 +165,19 @@ struct Host::Impl
 
         if (ipc == nullptr)
             ipc.reset(IPC::createDualSocketIPC(portNumber));
+       #ifdef __EMSCRIPTEN__
         else
             ipc->reconnect();
+       #endif
 
         last_error = ipc->last_error;
 
         if (last_error.empty())
             return true;
 
-        // ipc.reset();
+       #ifndef __EMSCRIPTEN__
+        ipc.reset();
+       #endif
         return false;
     }
 

--- a/src/host.cpp
+++ b/src/host.cpp
@@ -165,13 +165,15 @@ struct Host::Impl
 
         if (ipc == nullptr)
             ipc.reset(IPC::createDualSocketIPC(portNumber));
+        else
+            ipc->reconnect();
 
         last_error = ipc->last_error;
 
         if (last_error.empty())
             return true;
 
-        ipc.reset();
+        // ipc.reset();
         return false;
     }
 

--- a/src/host.cpp
+++ b/src/host.cpp
@@ -1426,6 +1426,11 @@ bool Host::poll_feedback() const
     return impl->poll();
 }
 
+void Host::close()
+{
+    impl->close();
+}
+
 bool Host::reconnect()
 {
     return impl->reconnect();

--- a/src/host.cpp
+++ b/src/host.cpp
@@ -164,11 +164,16 @@ struct Host::Impl
        #endif
 
         if (ipc == nullptr)
+        {
             ipc.reset(IPC::createDualSocketIPC(portNumber));
-       #ifdef __EMSCRIPTEN__
+        }
         else
+        {
+            ipc->last_error.clear();
+           #ifdef __EMSCRIPTEN__
             ipc->reconnect();
-       #endif
+           #endif
+        }
 
         last_error = ipc->last_error;
 

--- a/src/host.hpp
+++ b/src/host.hpp
@@ -462,6 +462,11 @@ struct Host {
     ~Host();
 
    /**
+     * close connection to host
+     */
+    void close();
+
+   /**
      * try to reconnect host if it previously failed
      */
     bool reconnect();

--- a/src/ipc.cpp
+++ b/src/ipc.cpp
@@ -262,7 +262,7 @@ struct IPC::Impl
         {
             // TCP server will return 0 when client is disconnected
             if (server)
-                last_error = format("readMessage fist byte disconnected, error: %d", getLastError());
+                last_error = format("readMessage first byte disconnected, error: %d", getLastError());
             else
                 last_error.clear();
             return nullptr;
@@ -274,7 +274,7 @@ struct IPC::Impl
             if (server && (errno == EAGAIN || errno == EWOULDBLOCK))
                 last_error.clear();
             else
-                last_error = format("readMessage fist byte error, return: %d, error: %d", r, getLastError());
+                last_error = format("readMessage first byte error, return: %d, error: %d", r, getLastError());
             return nullptr;
         }
 

--- a/src/ipc.cpp
+++ b/src/ipc.cpp
@@ -1078,7 +1078,6 @@ IPC::Impl::DualSocketTCP::~DualSocketTCP()
 
 bool IPC::Impl::DualSocketTCP::reconnect()
 {
-    printf("DualSocketTCP::reconnect\n");
    #ifdef __EMSCRIPTEN__
     unsigned short readyState;
     if (emscripten_websocket_get_ready_state(sockets.out, &readyState) != EMSCRIPTEN_RESULT_SUCCESS ||
@@ -1299,10 +1298,12 @@ IPC::~IPC()
     delete impl;
 }
 
+#ifdef __EMSCRIPTEN__
 bool IPC::reconnect()
 {
     return impl->reconnect();
 }
+#endif
 
 char* IPC::readMessage(uint32_t* const bytesRead)
 {

--- a/src/ipc.cpp
+++ b/src/ipc.cpp
@@ -54,26 +54,31 @@ struct BufferedRecvData {
             if (nonBlocking)
                 return 0;
 
-            emscripten_pause_main_loop();
+            // emscripten_pause_main_loop();
 
-            while (read == wrtn)
+            for (int i = 0; i < 200 && read == wrtn; ++i)
                 emscripten_sleep(5);
 
-            emscripten_resume_main_loop();
-            return -1;
+            // emscripten_resume_main_loop();
+
+            if (read == wrtn)
+            {
+                errno = EAGAIN;
+                return -1;
+            }
         }
 
         *c = data[read++];
 
         if (read == wrtn)
-            wrtn = 0;
+            read = wrtn = 0;
 
         return 1;
     }
 
     void push(const EmscriptenWebSocketMessageEvent* const event)
     {
-        if (wrtn + event->numBytes > size)
+        if (data == nullptr || wrtn + event->numBytes > size)
         {
             size = (wrtn + event->numBytes) * 2;
             data = static_cast<uint8_t*>(std::realloc(data, size));
@@ -982,19 +987,19 @@ IPC::Impl::DualSocketTCP::DualSocketTCP(std::string& last_error_, const int port
 
   #ifdef __EMSCRIPTEN__
     emscripten_websocket_set_onmessage_callback(
-        fbsock, this, [](const int eventType,
-                         const EmscriptenWebSocketMessageEvent* const event,
-                         void* const userData) -> EM_BOOL
-    {
-        static_cast<IPC::Impl::DualSocketTCP*>(userData)->sockets.fbbuffer.push(event);
-        return EM_TRUE;
-    });
-    emscripten_websocket_set_onmessage_callback(
         outsock, this, [](const int eventType,
                           const EmscriptenWebSocketMessageEvent* const event,
                           void* const userData) -> EM_BOOL
     {
         static_cast<IPC::Impl::DualSocketTCP*>(userData)->sockets.outbuffer.push(event);
+        return EM_TRUE;
+    });
+    emscripten_websocket_set_onmessage_callback(
+        fbsock, this, [](const int eventType,
+                         const EmscriptenWebSocketMessageEvent* const event,
+                         void* const userData) -> EM_BOOL
+    {
+        static_cast<IPC::Impl::DualSocketTCP*>(userData)->sockets.fbbuffer.push(event);
         return EM_TRUE;
     });
 

--- a/src/ipc.cpp
+++ b/src/ipc.cpp
@@ -50,7 +50,18 @@ struct BufferedRecvData {
         // TODO return ? if disconnected
 
         if (read == wrtn)
-            return nonBlocking ? 0 : -1;
+        {
+            if (nonBlocking)
+                return 0;
+
+            emscripten_pause_main_loop();
+
+            while (read == wrtn)
+                emscripten_sleep(5);
+
+            emscripten_resume_main_loop();
+            return -1;
+        }
 
         *c = data[read++];
 
@@ -74,6 +85,43 @@ struct BufferedRecvData {
         wrtn += event->numBytes;
     }
 };
+
+static EMSCRIPTEN_WEBSOCKET_T emSocketConnect(const int port)
+{
+    if (!emscripten_websocket_is_supported()) {
+        return INVALID_SOCKET;
+    }
+
+    printf("emSocketConnect %d\n", port);
+    char url[64];
+    EmscriptenWebSocketCreateAttributes attr = {
+        .url = url,
+        .protocols = nullptr,
+        .createOnMainThread = EM_TRUE,
+    };
+    std::snprintf(url, sizeof(url), "ws://localhost:%d", port);
+
+    const EMSCRIPTEN_WEBSOCKET_T socket = emscripten_websocket_new(&attr);
+    if (socket < 0)
+        return INVALID_SOCKET;
+
+    emscripten_websocket_set_onopen_callback(
+        socket, nullptr, [](const int eventType,
+                          const EmscriptenWebSocketOpenEvent* const event,
+                          void* const userData) -> EM_BOOL
+    {
+        return EM_TRUE;
+    });
+    emscripten_websocket_set_onerror_callback(
+        socket, nullptr, [](const int eventType,
+                          const EmscriptenWebSocketErrorEvent* const event,
+                          void* const userData) -> EM_BOOL
+    {
+        return EM_TRUE;
+    });
+
+    return socket;
+}
 #endif
 
 // --------------------------------------------------------------------------------------------------------------------
@@ -144,11 +192,6 @@ struct IPC::Impl
     Impl(std::string& last_error_)
         : last_error(last_error_)
     {
-       #ifdef __EMSCRIPTEN__
-        dummyDevMode = true;
-        return;
-       #endif
-
         bufferSize = 128;
         buffer = static_cast<char*>(std::malloc(bufferSize));
         assert(buffer != nullptr);
@@ -195,6 +238,11 @@ struct IPC::Impl
     void close()
     {
         iface.reset();
+    }
+
+    bool reconnect()
+    {
+        return iface != nullptr && iface->reconnect();
     }
 
     char* readMessage(uint32_t* const bytesRead)
@@ -583,6 +631,7 @@ private:
         std::string& last_error;
         Interface(std::string& last_error_) : last_error(last_error_) {};
         virtual ~Interface() = default;
+        [[nodiscard]] virtual bool reconnect() = 0;
         [[nodiscard]] virtual int setReadBlocking() = 0;
         virtual void setReadNonBlocking(int flags) = 0;
         [[nodiscard]] virtual int readMessageByte(char* c) = 0;
@@ -594,6 +643,7 @@ private:
     struct Serial : Interface {
         Serial(std::string& last_error_, const char* serial, int baudrate);
         ~Serial() override;
+        [[nodiscard]] bool reconnect() final;
         [[nodiscard]] int setReadBlocking() final;
         void setReadNonBlocking(int flags) final;
         [[nodiscard]] int readMessageByte(char* c) final;
@@ -608,6 +658,7 @@ private:
     struct SingleSocketTCP : Interface {
         SingleSocketTCP(std::string& last_error_, int port, bool isServer);
         ~SingleSocketTCP() override;
+        [[nodiscard]] bool reconnect() final;
         [[nodiscard]] int setReadBlocking() final;
         void setReadNonBlocking(int flags) final;
         [[nodiscard]] int readMessageByte(char* c) final;
@@ -627,6 +678,7 @@ private:
     struct DualSocketTCP : Interface {
         DualSocketTCP(std::string& last_error_, int port);
         ~DualSocketTCP() override;
+        [[nodiscard]] bool reconnect() final;
         [[nodiscard]] int setReadBlocking() final;
         void setReadNonBlocking(int flags) final;
         [[nodiscard]] int readMessageByte(char* c) final;
@@ -660,13 +712,6 @@ IPC::Impl::SingleSocketTCP::SingleSocketTCP(std::string& last_error_, const int 
         last_error = "Socket server not supported in web builds";
         return;
     }
-
-    char url[64];
-    EmscriptenWebSocketCreateAttributes attr = {
-        .url = url,
-        .protocols = "binary",
-        .createOnMainThread = EM_TRUE,
-    };
    #elif defined(_WIN32)
     if (! wsaInit(last_error))
         return;
@@ -675,8 +720,7 @@ IPC::Impl::SingleSocketTCP::SingleSocketTCP(std::string& last_error_, const int 
     SOCKET outsock, outsockfd;
 
    #ifdef __EMSCRIPTEN__
-    std::snprintf(url, sizeof(url), "ws://127.0.0.1:%d/websocket", port);
-    if (outsock = emscripten_websocket_new(&attr); outsock <= 0)
+    if (outsock = emSocketConnect(port); outsock == INVALID_SOCKET)
    #else
     if (outsock = socket(AF_INET, SOCK_STREAM, IPPROTO_TCP); outsock == INVALID_SOCKET)
    #endif
@@ -694,6 +738,12 @@ IPC::Impl::SingleSocketTCP::SingleSocketTCP(std::string& last_error_, const int 
         static_cast<IPC::Impl::SingleSocketTCP*>(userData)->sockets.outbuffer.push(event);
         return EM_TRUE;
     });
+
+    unsigned short readyState;
+    if (emscripten_websocket_get_ready_state(outsock, &readyState) != EMSCRIPTEN_RESULT_SUCCESS ||
+        readyState != 1)
+        last_error = "readyState error";
+
     sockets.outfd = outsock;
   #else
    #ifndef _WIN32
@@ -794,6 +844,23 @@ IPC::Impl::SingleSocketTCP::~SingleSocketTCP()
    #endif
 }
 
+bool IPC::Impl::SingleSocketTCP::reconnect()
+{
+   #ifdef __EMSCRIPTEN__
+    unsigned short readyState;
+    if (emscripten_websocket_get_ready_state(sockets.outfd, &readyState) != EMSCRIPTEN_RESULT_SUCCESS ||
+        readyState != 1)
+    {
+        last_error = "readyState error";
+        return false;
+    }
+    last_error.clear();
+    return true;
+   #else
+    return false;
+   #endif
+}
+
 int IPC::Impl::SingleSocketTCP::setReadBlocking()
 {
     assert(sockets.outfd != INVALID_SOCKET);
@@ -885,14 +952,7 @@ IPC::Impl::DualSocketTCP::DualSocketTCP(std::string& last_error_, const int port
 {
     last_error.clear();
 
-   #if defined(__EMSCRIPTEN__)
-    char url[64];
-    EmscriptenWebSocketCreateAttributes attr = {
-        .url = url,
-        .protocols = "binary",
-        .createOnMainThread = EM_TRUE,
-    };
-   #elif defined(_WIN32)
+   #ifdef _WIN32
     if (! wsaInit(last_error))
         return;
    #endif
@@ -900,8 +960,7 @@ IPC::Impl::DualSocketTCP::DualSocketTCP(std::string& last_error_, const int port
     SOCKET outsock, fbsock;
 
    #ifdef __EMSCRIPTEN__
-    std::snprintf(url, sizeof(url), "ws://127.0.0.1:%d/websocket", port);
-    if (outsock = emscripten_websocket_new(&attr); outsock <= 0)
+    if (outsock = emSocketConnect(port); outsock == INVALID_SOCKET)
    #else
     if (outsock = socket(AF_INET, SOCK_STREAM, IPPROTO_TCP); outsock == INVALID_SOCKET)
    #endif
@@ -911,8 +970,7 @@ IPC::Impl::DualSocketTCP::DualSocketTCP(std::string& last_error_, const int port
     }
 
    #ifdef __EMSCRIPTEN__
-    std::snprintf(url, sizeof(url), "ws://127.0.0.1:%d/websocket", port + 1);
-    if (fbsock = emscripten_websocket_new(&attr); fbsock <= 0)
+    if (fbsock = emSocketConnect(port + 1); fbsock == INVALID_SOCKET)
    #else
     if (fbsock = socket(AF_INET, SOCK_STREAM, IPPROTO_TCP); fbsock == INVALID_SOCKET)
    #endif
@@ -939,6 +997,13 @@ IPC::Impl::DualSocketTCP::DualSocketTCP(std::string& last_error_, const int port
         static_cast<IPC::Impl::DualSocketTCP*>(userData)->sockets.outbuffer.push(event);
         return EM_TRUE;
     });
+
+    unsigned short readyState;
+    if (emscripten_websocket_get_ready_state(outsock, &readyState) != EMSCRIPTEN_RESULT_SUCCESS ||
+        readyState != 1 ||
+        emscripten_websocket_get_ready_state(fbsock, &readyState) != EMSCRIPTEN_RESULT_SUCCESS ||
+        readyState != 1)
+        last_error = "readyState error";
   #else
    #ifndef _WIN32
     int value;
@@ -1008,6 +1073,30 @@ IPC::Impl::DualSocketTCP::~DualSocketTCP()
 
    #ifdef _WIN32
     wsaCleanup();
+   #endif
+}
+
+bool IPC::Impl::DualSocketTCP::reconnect()
+{
+    printf("DualSocketTCP::reconnect\n");
+   #ifdef __EMSCRIPTEN__
+    unsigned short readyState;
+    if (emscripten_websocket_get_ready_state(sockets.out, &readyState) != EMSCRIPTEN_RESULT_SUCCESS ||
+        readyState != 1)
+    {
+        last_error = "readyState error";
+        return false;
+    }
+    if (emscripten_websocket_get_ready_state(sockets.feedback, &readyState) != EMSCRIPTEN_RESULT_SUCCESS ||
+        readyState != 1)
+    {
+        last_error = "readyState error";
+        return false;
+    }
+    last_error.clear();
+    return true;
+   #else
+    return false;
    #endif
 }
 
@@ -1127,6 +1216,11 @@ IPC::Impl::Serial::~Serial()
     }
 }
 
+bool IPC::Impl::Serial::reconnect()
+{
+    return false;
+}
+
 int IPC::Impl::Serial::setReadBlocking()
 {
     readIsBlocking = true;
@@ -1203,6 +1297,11 @@ IPC::IPC()
 IPC::~IPC()
 {
     delete impl;
+}
+
+bool IPC::reconnect()
+{
+    return impl->reconnect();
 }
 
 char* IPC::readMessage(uint32_t* const bytesRead)

--- a/src/ipc.cpp
+++ b/src/ipc.cpp
@@ -11,7 +11,12 @@
 #include <cstring>
 #include <memory>
 
-#ifdef _WIN32
+#if defined(__EMSCRIPTEN__)
+#include <emscripten/websocket.h>
+#define closesocket emscripten_websocket_delete
+#define INVALID_SOCKET -1
+typedef EMSCRIPTEN_WEBSOCKET_T SOCKET;
+#elif defined(_WIN32)
 #include <winsock2.h>
 #else
 #include <fcntl.h>
@@ -28,6 +33,47 @@ typedef int SOCKET;
 #ifdef HAVE_SERIALPORT
 #include <libserialport.h>
 #define SERIALPORT_BLOCKING_READ_TIMEOUT_MS 40
+#endif
+
+// --------------------------------------------------------------------------------------------------------------------
+//
+
+#ifdef __EMSCRIPTEN__
+struct BufferedRecvData {
+    uint32_t size = 128;
+    uint32_t read = 0;
+    uint32_t wrtn = 0;
+    uint8_t* data = static_cast<uint8_t*>(std::malloc(size));
+
+    int pop(char* const c, const bool nonBlocking)
+    {
+        // TODO return ? if disconnected
+
+        if (read == wrtn)
+            return nonBlocking ? 0 : -1;
+
+        *c = data[read++];
+
+        if (read == wrtn)
+            wrtn = 0;
+
+        return 1;
+    }
+
+    void push(const EmscriptenWebSocketMessageEvent* const event)
+    {
+        if (wrtn + event->numBytes > size)
+        {
+            size = (wrtn + event->numBytes) * 2;
+            data = static_cast<uint8_t*>(std::realloc(data, size));
+        }
+
+        assert_return(data != nullptr,);
+
+        std::memcpy(data + wrtn, event->data, event->numBytes);
+        wrtn += event->numBytes;
+    }
+};
 #endif
 
 // --------------------------------------------------------------------------------------------------------------------
@@ -571,6 +617,10 @@ private:
         struct {
             SOCKET out = INVALID_SOCKET;
             SOCKET outfd = INVALID_SOCKET;
+           #ifdef __EMSCRIPTEN__
+            BufferedRecvData outbuffer = {};
+            bool nonBlocking = true;
+           #endif
         } sockets;
     };
 
@@ -586,6 +636,11 @@ private:
         struct {
             SOCKET out = INVALID_SOCKET;
             SOCKET feedback = INVALID_SOCKET;
+           #ifdef __EMSCRIPTEN__
+            BufferedRecvData outbuffer = {};
+            BufferedRecvData fbbuffer = {};
+            bool nonBlocking = true;
+           #endif
         } sockets;
     };
 
@@ -599,19 +654,48 @@ IPC::Impl::SingleSocketTCP::SingleSocketTCP(std::string& last_error_, const int 
 {
     last_error.clear();
 
-   #ifdef _WIN32
+   #if defined(__EMSCRIPTEN__)
+    if (isServer)
+    {
+        last_error = "Socket server not supported in web builds";
+        return;
+    }
+
+    char url[64];
+    EmscriptenWebSocketCreateAttributes attr = {
+        .url = url,
+        .protocols = "binary",
+        .createOnMainThread = EM_TRUE,
+    };
+   #elif defined(_WIN32)
     if (! wsaInit(last_error))
         return;
    #endif
 
     SOCKET outsock, outsockfd;
 
+   #ifdef __EMSCRIPTEN__
+    std::snprintf(url, sizeof(url), "ws://127.0.0.1:%d/websocket", port);
+    if (outsock = emscripten_websocket_new(&attr); outsock <= 0)
+   #else
     if (outsock = socket(AF_INET, SOCK_STREAM, IPPROTO_TCP); outsock == INVALID_SOCKET)
+   #endif
     {
         last_error = "output socket error";
         return;
     }
 
+  #ifdef __EMSCRIPTEN__
+    emscripten_websocket_set_onmessage_callback(
+        outsock, this, [](const int eventType,
+                          const EmscriptenWebSocketMessageEvent* const event,
+                          void* const userData) -> EM_BOOL
+    {
+        static_cast<IPC::Impl::SingleSocketTCP*>(userData)->sockets.outbuffer.push(event);
+        return EM_TRUE;
+    });
+    sockets.outfd = outsock;
+  #else
    #ifndef _WIN32
     int value;
 
@@ -681,6 +765,7 @@ IPC::Impl::SingleSocketTCP::SingleSocketTCP(std::string& last_error_, const int 
 
         sockets.outfd = outsock;
     }
+  #endif
 
     sockets.out = outsock;
 }
@@ -695,9 +780,11 @@ IPC::Impl::SingleSocketTCP::~SingleSocketTCP()
     const SOCKET outsockfd = sockets.outfd;
     sockets.out = sockets.outfd = INVALID_SOCKET;
 
+   #ifndef __EMSCRIPTEN__
     // shutdown connection first
     if (outsock != outsockfd)
         shutdown(outsockfd, SD_BOTH);
+   #endif
 
     // then the socket
     ::closesocket(outsock);
@@ -710,7 +797,10 @@ IPC::Impl::SingleSocketTCP::~SingleSocketTCP()
 int IPC::Impl::SingleSocketTCP::setReadBlocking()
 {
     assert(sockets.outfd != INVALID_SOCKET);
-   #ifdef _WIN32
+   #if defined(__EMSCRIPTEN__)
+    sockets.nonBlocking = false;
+    return 0;
+   #elif defined(_WIN32)
     unsigned long nonblocking = 0;
     ::ioctlsocket(sockets.outfd, FIONBIO, &nonblocking);
     return 0;
@@ -721,10 +811,12 @@ int IPC::Impl::SingleSocketTCP::setReadBlocking()
    #endif
 }
 
-void IPC::Impl::SingleSocketTCP::setReadNonBlocking(const int flags)
+void IPC::Impl::SingleSocketTCP::setReadNonBlocking(const int flags [[maybe_unused]])
 {
     assert(sockets.outfd != INVALID_SOCKET);
-   #ifdef _WIN32
+   #if defined(__EMSCRIPTEN__)
+    sockets.nonBlocking = true;
+   #elif defined(_WIN32)
     unsigned long nonblocking = 1;
     ::ioctlsocket(sockets.outfd, FIONBIO, &nonblocking);
    #else
@@ -734,12 +826,20 @@ void IPC::Impl::SingleSocketTCP::setReadNonBlocking(const int flags)
 
 int IPC::Impl::SingleSocketTCP::readMessageByte(char* const c)
 {
+   #ifdef __EMSCRIPTEN__
+    return sockets.outbuffer.pop(c, sockets.nonBlocking);
+   #else
     return recv(sockets.outfd, c, 1, 0);
+   #endif
 }
 
 int IPC::Impl::SingleSocketTCP::readResponseByte(char* const c)
 {
+   #ifdef __EMSCRIPTEN__
+    return sockets.outbuffer.pop(c, false);
+   #else
     return recv(sockets.outfd, c, 1, 0);
+   #endif
 }
 
 bool IPC::Impl::SingleSocketTCP::writeMessage(const std::string& message)
@@ -750,6 +850,13 @@ bool IPC::Impl::SingleSocketTCP::writeMessage(const std::string& message)
         return false;
     }
 
+   #ifdef __EMSCRIPTEN__
+    if (emscripten_websocket_send_utf8_text(sockets.outfd, message.c_str()) != EMSCRIPTEN_RESULT_SUCCESS)
+    {
+        last_error = "send error";
+        return false;
+    }
+   #else
     const char* buffer = message.c_str();
     size_t msgsize = message.size() + 1;
     int ret;
@@ -765,7 +872,8 @@ bool IPC::Impl::SingleSocketTCP::writeMessage(const std::string& message)
 
         msgsize -= ret;
         buffer += ret;
-     }
+    }
+   #endif
 
     return true;
 }
@@ -777,26 +885,61 @@ IPC::Impl::DualSocketTCP::DualSocketTCP(std::string& last_error_, const int port
 {
     last_error.clear();
 
-   #ifdef _WIN32
+   #if defined(__EMSCRIPTEN__)
+    char url[64];
+    EmscriptenWebSocketCreateAttributes attr = {
+        .url = url,
+        .protocols = "binary",
+        .createOnMainThread = EM_TRUE,
+    };
+   #elif defined(_WIN32)
     if (! wsaInit(last_error))
         return;
    #endif
 
     SOCKET outsock, fbsock;
 
+   #ifdef __EMSCRIPTEN__
+    std::snprintf(url, sizeof(url), "ws://127.0.0.1:%d/websocket", port);
+    if (outsock = emscripten_websocket_new(&attr); outsock <= 0)
+   #else
     if (outsock = socket(AF_INET, SOCK_STREAM, IPPROTO_TCP); outsock == INVALID_SOCKET)
+   #endif
     {
         last_error = "output socket error";
         return;
     }
 
+   #ifdef __EMSCRIPTEN__
+    std::snprintf(url, sizeof(url), "ws://127.0.0.1:%d/websocket", port + 1);
+    if (fbsock = emscripten_websocket_new(&attr); fbsock <= 0)
+   #else
     if (fbsock = socket(AF_INET, SOCK_STREAM, IPPROTO_TCP); fbsock == INVALID_SOCKET)
+   #endif
     {
         last_error = "feedback socket error";
         ::closesocket(outsock);
         return;
     }
 
+  #ifdef __EMSCRIPTEN__
+    emscripten_websocket_set_onmessage_callback(
+        fbsock, this, [](const int eventType,
+                         const EmscriptenWebSocketMessageEvent* const event,
+                         void* const userData) -> EM_BOOL
+    {
+        static_cast<IPC::Impl::DualSocketTCP*>(userData)->sockets.fbbuffer.push(event);
+        return EM_TRUE;
+    });
+    emscripten_websocket_set_onmessage_callback(
+        outsock, this, [](const int eventType,
+                          const EmscriptenWebSocketMessageEvent* const event,
+                          void* const userData) -> EM_BOOL
+    {
+        static_cast<IPC::Impl::DualSocketTCP*>(userData)->sockets.outbuffer.push(event);
+        return EM_TRUE;
+    });
+  #else
    #ifndef _WIN32
     int value;
 
@@ -844,6 +987,7 @@ IPC::Impl::DualSocketTCP::DualSocketTCP(std::string& last_error_, const int port
     const int socketflags = ::fcntl(fbsock, F_GETFL);
     ::fcntl(fbsock, F_SETFL, socketflags | O_NONBLOCK);
    #endif
+  #endif
 
     sockets.out = outsock;
     sockets.feedback = fbsock;
@@ -869,7 +1013,10 @@ IPC::Impl::DualSocketTCP::~DualSocketTCP()
 
 int IPC::Impl::DualSocketTCP::setReadBlocking()
 {
-   #ifdef _WIN32
+   #if defined(__EMSCRIPTEN__)
+    sockets.nonBlocking = false;
+    return 0;
+   #elif defined(_WIN32)
     unsigned long nonblocking = 0;
     ::ioctlsocket(sockets.feedback, FIONBIO, &nonblocking);
     return 0;
@@ -882,7 +1029,9 @@ int IPC::Impl::DualSocketTCP::setReadBlocking()
 
 void IPC::Impl::DualSocketTCP::setReadNonBlocking(const int flags [[maybe_unused]])
 {
-   #ifdef _WIN32
+   #if defined(__EMSCRIPTEN__)
+    sockets.nonBlocking = true;
+   #elif defined(_WIN32)
     unsigned long nonblocking = 1;
     ::ioctlsocket(sockets.feedback, FIONBIO, &nonblocking);
    #else
@@ -892,12 +1041,20 @@ void IPC::Impl::DualSocketTCP::setReadNonBlocking(const int flags [[maybe_unused
 
 int IPC::Impl::DualSocketTCP::readMessageByte(char* const c)
 {
+   #ifdef __EMSCRIPTEN__
+    return sockets.fbbuffer.pop(c, sockets.nonBlocking);
+   #else
     return recv(sockets.feedback, c, 1, 0);
+   #endif
 }
 
 int IPC::Impl::DualSocketTCP::readResponseByte(char* const c)
 {
+   #ifdef __EMSCRIPTEN__
+    return sockets.outbuffer.pop(c, false);
+   #else
     return recv(sockets.out, c, 1, 0);
+   #endif
 }
 
 bool IPC::Impl::DualSocketTCP::writeMessage(const std::string& message)
@@ -908,6 +1065,13 @@ bool IPC::Impl::DualSocketTCP::writeMessage(const std::string& message)
         return false;
     }
 
+   #ifdef __EMSCRIPTEN__
+    if (emscripten_websocket_send_utf8_text(sockets.out, message.c_str()) != EMSCRIPTEN_RESULT_SUCCESS)
+    {
+        last_error = "send error";
+        return false;
+    }
+   #else
     const char* buffer = message.c_str();
     size_t msgsize = message.size() + 1;
     int ret;
@@ -924,6 +1088,7 @@ bool IPC::Impl::DualSocketTCP::writeMessage(const std::string& message)
         msgsize -= ret;
         buffer += ret;
     }
+   #endif
 
     return true;
 }

--- a/src/ipc.hpp
+++ b/src/ipc.hpp
@@ -67,7 +67,12 @@ struct IPC
      */
     std::string last_error;
 
+   #ifdef __EMSCRIPTEN__
+    /**
+     * attempt to reconnect without having to recreate the IPC object.
+     */
     bool reconnect();
+   #endif
 
     /**
      * read a message.

--- a/src/ipc.hpp
+++ b/src/ipc.hpp
@@ -67,6 +67,8 @@ struct IPC
      */
     std::string last_error;
 
+    bool reconnect();
+
     /**
      * read a message.
      * returned value must not be freed, but it can be safely modified.

--- a/src/lv2.cpp
+++ b/src/lv2.cpp
@@ -20,7 +20,9 @@
 #include <list>
 #include <map>
 
+#ifndef __EMSCRIPTEN__
 #include <pthread.h>
+#endif
 
 #include <lilv/lilv.h>
 
@@ -402,6 +404,7 @@ struct Lv2NamespaceDefinitions {
 
 // --------------------------------------------------------------------------------------------------------------------
 
+#ifndef __EMSCRIPTEN__
 struct pthread_mutex_guard {
     pthread_mutex_t& mutex;
 
@@ -416,6 +419,7 @@ struct pthread_mutex_guard {
         pthread_mutex_unlock(&mutex);
     }
 };
+#endif
 
 // --------------------------------------------------------------------------------------------------------------------
 
@@ -456,6 +460,7 @@ struct Lv2World::Impl
             }
         }
 
+       #ifndef __EMSCRIPTEN__
         // create a priority-inversion recursive mutex
         // this way the thread can be low-priority and gets temporarily raised to normal priority as needed
         {
@@ -479,15 +484,18 @@ struct Lv2World::Impl
                            return nullptr;
                        },
                        this);
+       #endif
     }
 
     ~Impl()
     {
+       #ifndef __EMSCRIPTEN__
         bgLoadingActive = false;
         pthread_mutex_lock(&bgLoadingMutex);
         pthread_join(bgLoadingThread, nullptr);
         pthread_mutex_unlock(&bgLoadingMutex);
         pthread_mutex_destroy(&bgLoadingMutex);
+       #endif
 
         pluginsCache.clear();
 
@@ -527,7 +535,9 @@ struct Lv2World::Impl
         std::string bundlepath;
         const LilvPlugin* plugin;
 
+       #ifndef __EMSCRIPTEN__
         const pthread_mutex_guard pmg(bgLoadingMutex);
+       #endif
 
         if (LilvNode* const urinode = lilv_new_uri(world, uri))
         {
@@ -1224,7 +1234,9 @@ struct Lv2World::Impl
         if (cache.blockImageStyling != nullptr)
             return cache.blockImageStyling;
 
+       #ifndef __EMSCRIPTEN__
         const pthread_mutex_guard pmg(bgLoadingMutex);
+       #endif
 
         LilvNode* stylingNode = nullptr;
         {
@@ -1377,7 +1389,9 @@ struct Lv2World::Impl
         if (cache.blockSettingsStyling != nullptr)
             return cache.blockSettingsStyling;
 
+       #ifndef __EMSCRIPTEN__
         const pthread_mutex_guard pmg(bgLoadingMutex);
+       #endif
 
         LilvNode* stylingNode = nullptr;
         {
@@ -1774,7 +1788,9 @@ struct Lv2World::Impl
     {
         assert(path != nullptr && *path != '\0');
 
+       #ifndef __EMSCRIPTEN__
         const pthread_mutex_guard pmg(bgLoadingMutex);
+       #endif
 
         LV2_URID_Map uridMap = { this, _mapfn };
         LilvState* const state = lilv_state_new_from_file(world, &uridMap, nullptr, path);
@@ -1804,7 +1820,9 @@ struct Lv2World::Impl
         _pluginsInBundle(pluginsInBundle, path);
         assert_return(! pluginsInBundle.empty(), false);
 
+       #ifndef __EMSCRIPTEN__
         const pthread_mutex_guard pmg(bgLoadingMutex);
+       #endif
 
         // load the bundle
         if (LilvNode* const b = lilv_new_file_uri(world, nullptr, path))
@@ -1848,7 +1866,9 @@ struct Lv2World::Impl
         _pluginsInBundle(pluginsInBundle, path);
         assert_return(! pluginsInBundle.empty(), false);
 
+       #ifndef __EMSCRIPTEN__
         const pthread_mutex_guard pmg(bgLoadingMutex);
+       #endif
 
         // unload the bundle
         if (LilvNode* const b = lilv_new_file_uri(world, nullptr, path))
@@ -1883,7 +1903,9 @@ struct Lv2World::Impl
     {
         const LilvPlugin* plugin;
 
+       #ifndef __EMSCRIPTEN__
         const pthread_mutex_guard pmg(bgLoadingMutex);
+       #endif
 
         for (auto& it : pluginsCache)
         {
@@ -1936,6 +1958,7 @@ private:
     };
     std::unordered_map<std::string, PluginCache> pluginsCache;
 
+   #ifndef __EMSCRIPTEN__
     bool bgLoadingActive = true;
     pthread_t bgLoadingThread = {};
     pthread_mutex_t bgLoadingMutex;
@@ -1986,6 +2009,7 @@ private:
                 break;
         }
     }
+   #endif
 
     // NOTE Lv2PluginIsUserRemovable must have already been set, if relevant
     void updatePluginLicenseFlags(const char* const uri,

--- a/src/lv2.cpp
+++ b/src/lv2.cpp
@@ -1996,6 +1996,12 @@ private:
         {
             plugin->flags |= Lv2PluginIsCommercial;
 
+           #ifdef __EMSCRIPTEN__
+            // assume all plugins are licensed under wasm, just to make things easy
+            plugin->flags |= Lv2PluginIsLicensed;
+            return;
+           #endif
+
             static const std::string keysdir = _keysdir();
 
             std::string licensefile;

--- a/src/wasm/CMakeLists.txt
+++ b/src/wasm/CMakeLists.txt
@@ -1,0 +1,63 @@
+cmake_minimum_required(VERSION 3.15)
+project(mod-connector-wasm)
+
+set(CMAKE_C_STANDARD 17)
+set(CMAKE_CXX_STANDARD 17)
+
+set(MOD_CONNECTOR_LIB_ONLY TRUE)
+include(${CMAKE_CURRENT_SOURCE_DIR}/../../CMakeLists.txt)
+
+add_executable(mod-connector-wasm)
+
+# set_target_properties(mod-connector-wasm
+#     PROPERTIES
+#         SUFFIX ".js"
+# )
+
+target_compile_definitions(mod-connector-wasm
+    PRIVATE
+        _DARKGLASS_DEVICE_PABLITO
+        NUM_BINDING_ACTUATORS=10
+        NUM_BLOCK_CHAIN_ROWS=2
+        NUM_BLOCKS_PER_PRESET=12
+        NUM_SCENES_PER_PRESET=126
+)
+
+target_compile_options(mod-connector-wasm
+    PRIVATE
+        -fexceptions
+        -O3
+)
+
+target_link_libraries(mod-connector-wasm
+    PRIVATE
+        mod::connector
+)
+
+target_link_options(mod-connector-wasm
+    PRIVATE
+        # -Wl,--whole-archive
+        # -Wl,--no-whole-archive
+        --no-entry
+        --preload-file=${CMAKE_SOURCE_DIR}/lv2@/usr/lib/lv2
+        -fexceptions
+        -lwebsocket.js
+        -sAGGRESSIVE_VARIABLE_ELIMINATION=1
+        -sALLOW_MEMORY_GROWTH
+        # -sALLOW_TABLE_GROWTH
+        # -sASSERTIONS
+        -sASYNCIFY
+        -sASYNCIFY_IMPORTS=do_sleep
+        -sENVIRONMENT=web
+        -sEXPORT_NAME="connector"
+        -sEXPORTED_RUNTIME_METHODS=['ccall']
+        -sINITIAL_MEMORY=8Mb
+        -sLLD_REPORT_UNDEFINED
+        -sMAIN_MODULE=2
+        -sMODULARIZE=1
+)
+
+target_sources(mod-connector-wasm
+    PRIVATE
+        wasm-exports.cpp
+)

--- a/src/wasm/build-wasm.sh
+++ b/src/wasm/build-wasm.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+
+set -e
+
+cd $(dirname "${0}")/../..
+
+###############################################################################
+# setup PawPaw (builds extra static libs)
+
+export PAWPAW_FAST_MATH=1
+export PAWPAW_SKIP_FFTW=1
+export PAWPAW_SKIP_FLUIDSYNTH=1
+export PAWPAW_SKIP_GLIB=1
+export PAWPAW_SKIP_SAMPLERATE=1
+
+mkdir -p build-wasm
+[ -d build-wasm/PawPaw ] || git -C build-wasm clone https://github.com/DISTRHO/PawPaw.git
+
+./build-wasm/PawPaw/bootstrap-plugins.sh wasm
+
+###############################################################################
+# setup build
+
+source build-wasm/PawPaw/local.env wasm
+
+if [ "$(uname -s)" = "Darwin" ]; then
+    NUMJOBS=$(sysctl -n hw.logicalcpu)
+else
+    NUMJOBS=$(nproc)
+fi
+
+emcmake cmake -S src/wasm -B build-wasm -DCMAKE_BUILD_TYPE=Release
+cmake --build build-wasm -j ${NUMJOBS}
+
+###############################################################################
+# test build
+
+emrun src/wasm/wasm-test.html
+
+###############################################################################

--- a/src/wasm/wasm-exports.cpp
+++ b/src/wasm/wasm-exports.cpp
@@ -1,0 +1,670 @@
+// SPDX-FileCopyrightText: 2026 Filipe Coelho <falktx@darkglass.com>
+// SPDX-License-Identifier: ISC
+
+#include "connector.hpp"
+
+#include <emscripten.h>
+
+class HostConnectorExport : public HostConnector,
+                            private HostConnector::Callback
+{
+public:
+    HostConnectorExport()
+        : HostConnector(this) {}
+
+private:
+    void hostConnectorCallback(const HostCallbackData& data) final
+    {
+        fprintf(stderr, "hostConnectorCallback %d\n", data.type);
+    }
+
+    void hostDisconnectedCallback() final
+    {
+        fprintf(stderr, "hostDisconnectedCallback\n");
+    }
+};
+
+static HostConnectorExport* conn = new HostConnectorExport;
+
+// TODO apply "__attribute__((used))" to all functions at once
+
+extern "C" {
+
+// --------------------------------------------------------------------------------------------------------------------
+
+__attribute__((used))
+const char* test_string_return()
+{
+    return "This is a test string to verify that JS side can receive strings properly, does it work?";
+}
+
+__attribute__((used))
+void test_string_send(const char* s)
+{
+    fprintf(stderr, "We are on C++ side now! String is: '%s'\n", s);
+}
+
+// --------------------------------------------------------------------------------------------------------------------
+
+__attribute__((used))
+bool ok()
+{
+    return conn->ok;
+}
+
+__attribute__((used))
+void disconnect()
+{
+    conn->disconnect();
+}
+
+__attribute__((used))
+bool reconnect()
+{
+    return conn->reconnect();
+}
+
+__attribute__((used))
+const char* getLastError()
+{
+    static std::string ret;
+    ret = conn->getLastError();
+    return ret.c_str();
+}
+
+__attribute__((used))
+void monitorBlocksCPULoad(bool enable)
+{
+    conn->monitorBlocksCPULoad(enable);
+}
+
+__attribute__((used))
+bool monitorMidiControl(uint8_t midiChannel, bool enable)
+{
+    return conn->monitorMidiControl(midiChannel, enable);
+}
+
+__attribute__((used))
+bool monitorMidiProgram(uint8_t midiChannel, bool enable)
+{
+    return conn->monitorMidiProgram(midiChannel, enable);
+}
+
+__attribute__((used))
+void pollHostUpdates()
+{
+    conn->pollHostUpdates();
+}
+
+__attribute__((used))
+void requestHostUpdates()
+{
+    conn->requestHostUpdates();
+}
+
+__attribute__((used))
+void waitAudioCycle()
+{
+    conn->waitAudioCycle();
+}
+
+// --------------------------------------------------------------------------------------------------------------------
+// debug helpers
+
+__attribute__((used))
+const char* getBlockId(uint8_t row, uint8_t block)
+{
+    static std::string ret;
+    ret = conn->getBlockId(row, block);
+    return ret.c_str();
+}
+
+__attribute__((used))
+const char* getBlockIdNoPair(uint8_t row, uint8_t block)
+{
+    static std::string ret;
+    ret = conn->getBlockIdNoPair(row, block);
+    return ret.c_str();
+}
+
+__attribute__((used))
+const char* getBlockIdPairOnly(uint8_t row, uint8_t block)
+{
+    static std::string ret;
+    ret = conn->getBlockIdPairOnly(row, block);
+    return ret.c_str();
+}
+
+__attribute__((used))
+void printStateForDebug(bool withBlocks, bool withParams, bool withBindings)
+{
+    conn->printStateForDebug(withBlocks, withParams, withBindings);
+}
+
+// --------------------------------------------------------------------------------------------------------------------
+// cpu load handling
+
+__attribute__((used))
+void enableCpuLoadUpdates(bool enable)
+{
+    conn->enableCpuLoadUpdates(enable);
+}
+
+__attribute__((used))
+float getAverageCpuLoad()
+{
+    return conn->getAverageCpuLoad();
+}
+
+__attribute__((used))
+float getMaximumCpuLoad()
+{
+    return conn->getMaximumCpuLoad();
+}
+
+// --------------------------------------------------------------------------------------------------------------------
+// current state handling
+
+// __attribute__((used))
+// const Preset& getBankPreset(uint8_t preset)
+
+// __attribute__((used))
+// const Preset& getCurrentPreset(uint8_t preset)
+
+__attribute__((used))
+bool canAddSidechainInput(uint8_t row, uint8_t block)
+{
+    return conn->canAddSidechainInput(row, block);
+}
+
+__attribute__((used))
+bool canAddSidechainOutput(uint8_t row, uint8_t block)
+{
+    return conn->canAddSidechainOutput(row, block);
+}
+
+__attribute__((used))
+bool setJackPorts(const char* capture1, const char* capture2, const char* playback1, const char* playback2)
+{
+    const std::array<std::string, 2> capture = { capture1, capture2 };
+    const std::array<std::string, 2> playback = { playback1, playback2 };
+    return conn->setJackPorts(capture, playback);
+}
+
+__attribute__((used))
+void hostReady()
+{
+    conn->hostReady();
+}
+
+__attribute__((used))
+void enableAudioProcessing(bool enable)
+{
+    conn->enableAudioProcessing(enable);
+}
+
+__attribute__((used))
+void setDirty(bool dirty = true)
+{
+    conn->setDirty(dirty);
+}
+
+// --------------------------------------------------------------------------------------------------------------------
+// bank handling
+
+__attribute__((used))
+void loadBankFromPresetFiles(const char* filename1,
+                             const char* filename2,
+                             const char* filename3,
+                             uint8_t initialPresetToLoad = 0)
+{
+    const std::array<std::string, NUM_PRESETS_PER_BANK> filenames = { filename1, filename2, filename3 };
+    conn->loadBankFromPresetFiles(filenames);
+}
+
+// --------------------------------------------------------------------------------------------------------------------
+// preset handling
+
+__attribute__((used))
+const char* getPresetNameFromFile(const char* filename)
+{
+    static std::string ret;
+    ret = ::getPresetNameFromFile(filename);
+    return ret.c_str();
+}
+
+__attribute__((used))
+bool loadCurrentPresetFromFile(const char* filename, bool replaceDefault)
+{
+    return conn->loadCurrentPresetFromFile(filename, replaceDefault);
+}
+
+__attribute__((used))
+bool preloadPresetFromFile(uint8_t preset, const char* filename)
+{
+    return conn->preloadPresetFromFile(preset, filename);
+}
+
+__attribute__((used))
+bool saveCurrentPresetToFile(const char* filename)
+{
+    return conn->saveCurrentPresetToFile(filename);
+}
+
+__attribute__((used))
+bool reorderPresets(uint8_t orig, uint8_t dest)
+{
+    return conn->reorderPresets(orig, dest);
+}
+
+__attribute__((used))
+void swapPresets(uint8_t presetA, uint8_t presetB, bool swapFiles = true)
+{
+    conn->swapPresets(presetA, presetB, swapFiles);
+}
+
+__attribute__((used))
+bool saveCurrentPreset()
+{
+    return conn->saveCurrentPreset();
+}
+
+__attribute__((used))
+void clearCurrentPreset()
+{
+    conn->clearCurrentPreset();
+}
+
+__attribute__((used))
+void clearCurrentPresetBackground()
+{
+    conn->clearCurrentPresetBackground();
+}
+
+__attribute__((used))
+void regenUUID()
+{
+    conn->regenUUID();
+}
+
+__attribute__((used))
+void setPresetFilename(uint8_t preset, const char* filename)
+{
+    conn->setPresetFilename(preset, filename);
+}
+
+__attribute__((used))
+void setCurrentPresetName(const char* name)
+{
+    conn->setCurrentPresetName(name);
+}
+
+// __attribute__((used))
+// void setCurrentPresetFilename(const char* filename)
+// {
+//     setPresetFilename(_current.preset, filename);
+// }
+
+__attribute__((used))
+bool switchPreset(uint8_t preset)
+{
+    return conn->switchPreset(preset);
+}
+
+__attribute__((used))
+void renamePreset(uint8_t preset, const char* name)
+{
+    return conn->renamePreset(preset, name);
+}
+
+// --------------------------------------------------------------------------------------------------------------------
+// block handling
+
+__attribute__((used))
+bool enableBlock(uint8_t row, uint8_t block, bool enable, HostSceneMode sceneMode)
+{
+    return conn->enableBlock(row, block, enable, sceneMode);
+}
+
+__attribute__((used))
+bool reorderBlock(uint8_t row, uint8_t orig, uint8_t dest)
+{
+    return conn->reorderBlock(row, orig, dest);
+}
+
+__attribute__((used))
+bool replaceBlock(uint8_t row,
+                  uint8_t block,
+                  const char* uri,
+                  bool clearBindingsForReplacementBlock = true,
+                  bool keepCurrentData = false)
+{
+    return conn->replaceBlock(row, block, uri, clearBindingsForReplacementBlock, keepCurrentData);
+}
+
+__attribute__((used))
+bool replaceBlockWhileKeepingCurrentData(uint8_t row, uint8_t block, const char* uri)
+{
+    return conn->replaceBlockWhileKeepingCurrentData(row, block, uri);
+}
+
+__attribute__((used))
+bool resetBlock(uint8_t row, uint8_t block, bool resetUserDefaults = false)
+{
+    return conn->resetBlock(row, block, resetUserDefaults);
+}
+
+__attribute__((used))
+bool saveBlockStateAsDefault(uint8_t row, uint8_t block)
+{
+    return conn->saveBlockStateAsDefault(row, block);
+}
+
+#if NUM_BLOCK_CHAIN_ROWS > 1
+__attribute__((used))
+bool swapBlockRow(uint8_t row, uint8_t block, uint8_t emptyRow, uint8_t emptyBlock)
+{
+    return conn->swapBlockRow(row, block, emptyRow, emptyBlock);
+}
+#endif
+
+// --------------------------------------------------------------------------------------------------------------------
+// scene handling (within the current preset)
+
+__attribute__((used))
+void clearAllScenes()
+{
+    conn->clearAllScenes();
+}
+
+__attribute__((used))
+void clearScene(uint8_t scene)
+{
+    conn->clearScene(scene);
+}
+
+__attribute__((used))
+bool copyScene(uint8_t orig, uint8_t dest)
+{
+    return conn->copyScene(orig, dest);
+}
+
+__attribute__((used))
+bool reorderScenes(uint8_t orig, uint8_t dest)
+{
+    return conn->reorderScenes(orig, dest);
+}
+
+__attribute__((used))
+void swapScenes(uint8_t sceneA, uint8_t sceneB)
+{
+    return conn->swapScenes(sceneA, sceneB);
+}
+
+__attribute__((used))
+bool switchScene(uint8_t scene, bool switchEvenIfSameScene = false, bool discardIfUnused = true)
+{
+    return conn->switchScene(scene, switchEvenIfSameScene, discardIfUnused);
+}
+
+__attribute__((used))
+bool renameScene(uint8_t scene, const char* name)
+{
+    return conn->renameScene(scene, name);
+}
+
+// __attribute__((used))
+// inline bool renameCurrentScene(const char* name)
+// {
+//     return renameScene(_current.scene, name);
+// }
+
+// --------------------------------------------------------------------------------------------------------------------
+// bindings NOTICE WORK-IN-PROGRESS
+
+__attribute__((used))
+bool addBlockBinding(uint8_t hwid, uint8_t row, uint8_t block)
+{
+    return conn->addBlockBinding(hwid, row, block);
+}
+
+__attribute__((used))
+bool addBlockParameterBinding(uint8_t hwid, uint8_t row, uint8_t block, uint8_t paramIndex)
+{
+    return conn->addBlockParameterBinding(hwid, row, block, paramIndex);
+}
+
+__attribute__((used))
+bool editBlockBinding(uint8_t hwid, uint8_t row, uint8_t block, bool inverted)
+{
+    return conn->editBlockBinding(hwid, row, block, inverted);
+}
+
+__attribute__((used))
+bool editBlockParameterBinding(uint8_t hwid,
+                                uint8_t row,
+                                uint8_t block,
+                                uint8_t paramIndex,
+                                float min,
+                                float max)
+{
+    return conn->editBlockParameterBinding(hwid, row, block, paramIndex, min, max);
+}
+
+__attribute__((used))
+bool removeBindings(uint8_t hwid)
+{
+    return conn->removeBindings(hwid);
+}
+
+__attribute__((used))
+bool removeBlockBinding(uint8_t hwid, uint8_t row, uint8_t block)
+{
+    return conn->removeBlockBinding(hwid, row, block);
+}
+
+__attribute__((used))
+bool removeBlockParameterBinding(uint8_t hwid, uint8_t row, uint8_t block, uint8_t paramIndex)
+{
+    return conn->removeBlockParameterBinding(hwid, row, block, paramIndex);
+}
+
+__attribute__((used))
+bool renameBinding(uint8_t hwid, const char* name)
+{
+    return conn->renameBinding(hwid, name);
+}
+
+__attribute__((used))
+bool replaceBlockBinding(uint8_t hwid, uint8_t row, uint8_t block, uint8_t rowB, uint8_t blockB)
+{
+    return conn->replaceBlockBinding(hwid, row, block, rowB, blockB);
+}
+
+__attribute__((used))
+bool replaceBlockParameterBinding(uint8_t hwid,
+                                  uint8_t row,
+                                  uint8_t block,
+                                  uint8_t paramIndex,
+                                  uint8_t rowB,
+                                  uint8_t blockB,
+                                  uint8_t paramIndexB)
+{
+    return conn->replaceBlockParameterBinding(hwid, row, block, paramIndex, rowB, blockB, paramIndexB);
+}
+
+__attribute__((used))
+bool reorderBlockBinding(uint8_t hwid, uint8_t dest)
+{
+    return conn->reorderBlockBinding(hwid, dest);
+}
+
+__attribute__((used))
+void setBindingValue(uint8_t hwid, double value, HostSceneMode sceneMode, bool updateBindings = true)
+{
+    conn->setBindingValue(hwid, value, sceneMode, updateBindings);
+}
+
+// --------------------------------------------------------------------------------------------------------------------
+// parameters
+
+__attribute__((used))
+void setBlockParameter(uint8_t row,
+                       uint8_t block,
+                       uint8_t paramIndex,
+                       float value,
+                       HostSceneMode sceneMode = HostConnector::kSceneModeClear)
+{
+    conn->setBlockParameter(row, block, paramIndex, value, sceneMode);
+}
+
+__attribute__((used))
+void setBlockParameterBySymbol(uint8_t row,
+                               uint8_t block,
+                               const char* symbol,
+                               float value,
+                               HostSceneMode sceneMode = HostConnector::kSceneModeClear)
+{
+    conn->setBlockParameter(row, block, symbol, value, sceneMode);
+}
+
+__attribute__((used))
+void setBlockQuickPot(uint8_t row, uint8_t block, uint8_t paramIndex)
+{
+    conn->setBlockQuickPot(row, block, paramIndex);
+}
+
+__attribute__((used))
+bool monitorBlockOutputParameter(uint8_t row, uint8_t block, uint8_t paramIndex, bool enable = true)
+{
+    return conn->monitorBlockOutputParameter(row, block, paramIndex, enable);
+}
+
+// --------------------------------------------------------------------------------------------------------------------
+// tempo handling NOTICE WORK-IN-PROGRESS
+
+__attribute__((used))
+bool setBeatsPerBar(double beatsPerBar)
+{
+    return conn->setBeatsPerBar(beatsPerBar);
+}
+
+__attribute__((used))
+bool setBeatsPerMinute(double beatsPerMinute)
+{
+    return conn->setBeatsPerMinute(beatsPerMinute);
+}
+
+__attribute__((used))
+bool transport(bool rolling, double beatsPerBar, double beatsPerMinute)
+{
+    return conn->transport(rolling, beatsPerBar, beatsPerMinute);
+}
+
+// --------------------------------------------------------------------------------------------------------------------
+// tool handling NOTICE WORK-IN-PROGRESS
+
+__attribute__((used))
+bool enableTool(uint8_t toolIndex, const char* uri, bool prerun = false)
+{
+    return conn->enableTool(toolIndex, uri, prerun);
+}
+
+__attribute__((used))
+void connectToolAudioInput(uint8_t toolIndex, const char* symbol, const char* jackPort, bool safe = false)
+{
+    conn->connectToolAudioInput(toolIndex, symbol, jackPort, safe);
+}
+
+__attribute__((used))
+void connectToolAudioOutput(uint8_t toolIndex, const char* symbol, const char* jackPort)
+{
+    conn->connectToolAudioOutput(toolIndex, symbol, jackPort);
+}
+
+__attribute__((used))
+void connectTool2Tool(uint8_t toolAIndex,
+                      const char* toolAOutSymbol,
+                      uint8_t toolBIndex,
+                      const char* toolBInSymbol)
+{
+    conn->connectTool2Tool(toolAIndex, toolAOutSymbol, toolBIndex, toolBInSymbol);
+}
+
+__attribute__((used))
+void connectBlock2Tool(uint8_t row,
+                       uint8_t block,
+                       uint8_t toolIndex,
+                       const char* toolInSymbolL,
+                       const char* toolInSymbolR = nullptr,
+                       const char* toolInSymbolSidechainL = nullptr,
+                       const char* toolInSymbolSidechainR = nullptr)
+{
+    conn->connectBlock2Tool(row, block, toolIndex, toolInSymbolL, toolInSymbolR, toolInSymbolSidechainL, toolInSymbolSidechainR);
+}
+
+__attribute__((used))
+void connectBlockAudioInput2Tool(uint8_t row,
+                                 uint8_t block,
+                                 uint8_t toolIndex,
+                                 const char* toolInSymbolL,
+                                 const char* toolInSymbolR = nullptr,
+                                 const char* toolInSymbolSidechainL = nullptr,
+                                 const char* toolInSymbolSidechainR = nullptr)
+{
+    conn->connectBlockAudioInput2Tool(row, block, toolIndex, toolInSymbolL, toolInSymbolR, toolInSymbolSidechainL, toolInSymbolSidechainR);
+}
+
+__attribute__((used))
+void disconnectToolAudioPort(uint8_t toolIndex, const char* symbol)
+{
+    conn->disconnectToolAudioPort(toolIndex, symbol);
+}
+
+__attribute__((used))
+void mapToolParameterToMIDICC(uint8_t toolIndex,
+                              const char* symbol,
+                              uint8_t channel,
+                              uint8_t cc,
+                              float minimum,
+                              float maximum)
+{
+    conn->mapToolParameterToMIDICC(toolIndex, symbol, channel, cc, minimum, maximum);
+}
+
+__attribute__((used))
+void unmapToolParameterFromMIDICC(uint8_t toolIndex, const char* symbol)
+{
+    conn->unmapToolParameterFromMIDICC(toolIndex, symbol);
+}
+
+__attribute__((used))
+void setToolParameter(uint8_t toolIndex, const char* symbol, float value)
+{
+    conn->setToolParameter(toolIndex, symbol, value);
+}
+
+__attribute__((used))
+void monitorToolOutputParameter(uint8_t toolIndex, const char* symbol, bool enable = true)
+{
+    conn->monitorToolOutputParameter(toolIndex, symbol, enable);
+}
+
+// --------------------------------------------------------------------------------------------------------------------
+// properties
+
+__attribute__((used))
+void setBlockProperty(uint8_t row, uint8_t block, uint8_t propIndex, const char* value)
+{
+    conn->setBlockProperty(row, block, propIndex, value);
+}
+
+__attribute__((used))
+void setBlockPropertyByURI(uint8_t row, uint8_t block, const char* uri, const char* value)
+{
+    conn->setBlockProperty(row, block, uri, value);
+}
+
+// --------------------------------------------------------------------------------------------------------------------
+
+} // extern "C"

--- a/src/wasm/wasm-exports.cpp
+++ b/src/wasm/wasm-exports.cpp
@@ -142,6 +142,44 @@ void printStateForDebug(bool withBlocks, bool withParams, bool withBindings)
 }
 
 // --------------------------------------------------------------------------------------------------------------------
+// wasm helpers
+
+__attribute__((used))
+const char* serializeCurrentPreset()
+{
+    static std::string ret;
+    ret = conn->serializeCurrentPreset();
+    return ret.c_str();
+}
+
+__attribute__((used))
+float getBlockParameter(uint8_t row, uint8_t block, uint8_t paramIndex)
+{
+    return conn->current.block(row, block).parameters[paramIndex].value;
+}
+
+__attribute__((used))
+float getBlockParameterBySymbol(uint8_t row, uint8_t block, const char* symbol)
+{
+    const HostBlock& blockdata = conn->current.block(row, block);
+    if (uint8_t paramIndex = blockdata.parameterIndexForSymbol(symbol); paramIndex != UINT8_MAX)
+        return blockdata.parameters[paramIndex].value;
+    return 0.f;
+}
+
+__attribute__((used))
+uint8_t getBlockQuickPotIndex(uint8_t row, uint8_t block)
+{
+    return conn->current.block(row, block).meta.quickPotIndex;
+}
+
+__attribute__((used))
+const char* getBlockQuickPotSymbol(uint8_t row, uint8_t block)
+{
+    return conn->current.block(row, block).quickPotSymbol.c_str();
+}
+
+// --------------------------------------------------------------------------------------------------------------------
 // cpu load handling
 
 __attribute__((used))
@@ -219,7 +257,7 @@ void loadBankFromPresetFiles(const char* filename1,
                              uint8_t initialPresetToLoad = 0)
 {
     const std::array<std::string, NUM_PRESETS_PER_BANK> filenames = { filename1, filename2, filename3 };
-    conn->loadBankFromPresetFiles(filenames);
+    conn->loadBankFromPresetFiles(filenames, initialPresetToLoad);
 }
 
 // --------------------------------------------------------------------------------------------------------------------
@@ -314,7 +352,7 @@ bool switchPreset(uint8_t preset)
 __attribute__((used))
 void renamePreset(uint8_t preset, const char* name)
 {
-    return conn->renamePreset(preset, name);
+    conn->renamePreset(preset, name);
 }
 
 // --------------------------------------------------------------------------------------------------------------------
@@ -398,7 +436,7 @@ bool reorderScenes(uint8_t orig, uint8_t dest)
 __attribute__((used))
 void swapScenes(uint8_t sceneA, uint8_t sceneB)
 {
-    return conn->swapScenes(sceneA, sceneB);
+    conn->swapScenes(sceneA, sceneB);
 }
 
 __attribute__((used))

--- a/src/wasm/wasm-test.html
+++ b/src/wasm/wasm-test.html
@@ -52,9 +52,7 @@
                       connector.setBlockParameterBySymbol = (row, block, symbol, value, sceneMode = kSceneModeClear) =>
                           connector.ccall("setBlockParameterBySymbol", "void", ["number", "number", "string", "double", "number"], [row, block, symbol, value, sceneMode], {async: true});
 
-                      // TESTING remove these later
-                      connector.test_string_return = () => connector.ccall("test_string_return", "string", [], []);
-                      connector.test_string_send = (s) => connector.ccall("test_string_send", "void", ["string"], [s]);
+                      connector.serializeCurrentPreset = () => connector.ccall("serializeCurrentPreset", "string", [], []);
 
                       console.log("connector wasm loaded, connecting...");
                       tryConnectingNow();
@@ -103,6 +101,9 @@
                   // and now to control parameters!
                   await connector.setBlockParameterBySymbol(0, 3, "Dry", 4.0);
                   await connector.setBlockParameterBySymbol(0, 3, "Wet", 6.0);
+
+                  // test serializing state
+                  console.log(connector.serializeCurrentPreset());
 
                   console.log("wasm usage testing complete!");
               }

--- a/src/wasm/wasm-test.html
+++ b/src/wasm/wasm-test.html
@@ -1,0 +1,122 @@
+<!DOCTYPE html>
+<html lang="">
+  <head>
+    <meta charset="utf-8">
+    <title>mod-connector wasm test</title>
+    <script>
+        let connector = null;
+        // init wasm in anonymous scope
+        (async function () {
+          try {
+              let resp;
+              resp = await fetch('/mod-connector-wasm.js');
+              if (!resp.ok) {
+                  throw ('Failed to download wasm-js file');
+              }
+              const wasmJs = await resp.text();
+              resp = await fetch('/mod-connector-wasm.wasm');
+              if (!resp.ok) {
+                  throw ('Failed to download wasm-blob file');
+              }
+              const wasmBlob = await resp.arrayBuffer();
+              const wasmJsFn = new Function(wasmJs + 'return connector;');
+              const createModule = wasmJsFn.call();
+              // create the wasm module and instance
+              createModule({
+                  instantiateWasm: (imports, successCallback) => {
+                      WebAssembly.instantiate(wasmBlob, imports)
+                          .then(output => { successCallback(output.instance, output.module); })
+                          // .catch((error) => { wasm.error = '' + error; });
+                      return {};
+                  },
+                  postRun: function (module) {
+                      connector = module;
+
+                      const kSceneModeClear = 1;
+
+                      // setup known functions for easy JS usage
+                      // NOTE some are async and return a Promise
+                      connector.ok = () => connector.ccall("ok", "boolean", [], []);
+                      connector.disconnect = () => connector.ccall("disconnect", "void", [], []);
+                      connector.reconnect = () => connector.ccall("reconnect", "boolean", [], []);
+                      connector.getLastError = () => connector.ccall("getLastError", "string", [], []);
+                      // TODO write them all!
+                      connector.getAverageCpuLoad = () => connector.ccall("getAverageCpuLoad", "number", [], [], {async: true});
+                      connector.getMaximumCpuLoad = () => connector.ccall("getMaximumCpuLoad", "number", [], [], {async: true});
+                      connector.loadBankFromPresetFiles = (f1, f2, f3, init = 0) => connector.ccall("loadBankFromPresetFiles", "boolean", ["string", "string", "string", "number"], [f1, f2, f3, init], {async: true});
+                      connector.clearCurrentPreset = () => connector.ccall("clearCurrentPreset", "void", [], [], {async: true});
+                      connector.switchPreset = (preset) => connector.ccall("switchPreset", "boolean", ["number"], [preset], {async: true});
+                      connector.setJackPorts = (c1, c2, p1, p2) => connector.ccall("setJackPorts", "boolean", ["string", "string", "string", "string"], [c1, c2, p1, p2], {async: true});
+                      connector.replaceBlock = (row, block, uri, clearBindingsForReplacementBlock = true, keepCurrentData = false) =>
+                          connector.ccall("replaceBlock", "boolean", ["number", "number", "string", "boolean", "boolean"], [row, block, uri, clearBindingsForReplacementBlock, keepCurrentData], {async: true});
+                      connector.setBlockParameterBySymbol = (row, block, symbol, value, sceneMode = kSceneModeClear) =>
+                          connector.ccall("setBlockParameterBySymbol", "void", ["number", "number", "string", "double", "number"], [row, block, symbol, value, sceneMode], {async: true});
+
+                      // TESTING remove these later
+                      connector.test_string_return = () => connector.ccall("test_string_return", "string", [], []);
+                      connector.test_string_send = (s) => connector.ccall("test_string_send", "void", ["string"], [s]);
+
+                      console.log("connector wasm loaded, connecting...");
+                      tryConnectingNow();
+                  },
+              });
+          }
+          catch (error) {
+              console.error('wasm init error: ', error);
+          }
+        })();
+
+        const tryConnectingNow = () => {
+            if (connector && (connector._ok() || connector._reconnect())) {
+                connectedCallback();
+                return;
+            }
+            setTimeout(tryConnectingNow, 100);
+        };
+
+        const connectedCallback = async () => {
+              console.log("connector wasm connected!");
+
+              console.log("test calling C function directly, must return true for 'connected ok' ->", connector.ok());
+              console.log("test returning string from C ->", connector.test_string_return());
+              /* test sending string to C */ connector.test_string_send("oi oi oi");
+              console.log("test message with response, getAverageCpuLoad ->", await connector.getAverageCpuLoad());
+              console.log("test message with response, getMaximumCpuLoad ->", await connector.getMaximumCpuLoad());
+
+              // NOTE the code below this line can be used to create a custom chain.
+              // because we lack preset data sync, always clear current bank first so we start from a known state
+              try {
+                  console.log("start wasm usage testing...");
+
+                  // this is required for now, assumes looper in INPUT position
+                  await connector.setJackPorts("effect_9990:output_l", "effect_9990:output_l", "anagram-output:in1", "anagram-output:in2");
+
+                  // simulate a first load, also required for now
+                  await connector.loadBankFromPresetFiles("/tmp/p1.json", "/tmp/p2.json", "/tmp/p3.json");
+
+                  // now we should be with an empty chain, let's try to add some FX
+                  await connector.replaceBlock(0, 0, "urn:darkglass:Suppressor");
+                  await connector.replaceBlock(0, 1, "urn:darkglass:moerfer");
+                  await connector.replaceBlock(0, 2, "urn:darkglass:B3K");
+                  await connector.replaceBlock(0, 3, "urn:darkglass:HallReverb");
+
+                  // and now to control parameters!
+                  await connector.setBlockParameterBySymbol(0, 3, "Dry", 4.0);
+                  await connector.setBlockParameterBySymbol(0, 3, "Wet", 6.0);
+
+                  console.log("wasm usage testing complete!");
+              }
+              catch (error) {
+                  console.error('wasm test error: ', error);
+              }
+        }
+    </script>
+  </head>
+  <body>
+    <header></header>
+    <main></main>
+    <footer></footer>
+    <script>
+    </script>
+  </body>
+</html>

--- a/tests/buildlib/CMakeLists.txt
+++ b/tests/buildlib/CMakeLists.txt
@@ -4,10 +4,10 @@ project(mod-connector-lib-test)
 set(CMAKE_C_STANDARD 17)
 set(CMAKE_CXX_STANDARD 17)
 
-set(MOD_CONNECTOR_TESTS TRUE)
+set(MOD_CONNECTOR_LIB_ONLY TRUE)
 include(${CMAKE_CURRENT_SOURCE_DIR}/../../CMakeLists.txt)
 
-add_executable(mod-connector-lib-test main.cpp)
+add_executable(mod-connector-lib-test)
 
 target_link_libraries(mod-connector-lib-test
     PRIVATE


### PR DESCRIPTION
Adds an implementation of the IPC mechanism for WebSocket when built through emscripten, using custom emscripten APIs (as to not need to write JavaScript code in this project).
This is used to build for web, as a wasm module.

Note that web connections are async so it needs a bit of custom logic for the initial connection.
Instead of block-waiting on the IPC constructor, we need to check back at regular intervals to know if the connection is successful or error.

One possible problem on this implementation is the data receiver, which we purposefully use as blocking on the regular/desktop/embed builds (wait until operation completed and host sent a response).
Specifically this:
```c
            emscripten_pause_main_loop();

            while (read == wrtn)
                emscripten_sleep(5);

            emscripten_resume_main_loop();
```

This requires `-sASYNCIFY` which might cause issues when the wasm build is used as a module.

Marked as draft as this still needs to be tested in full.
