### PR TITLE
Optimize replaceBlock()

### DIFF
--- a/src/connector.cpp
+++ b/src/connector.cpp
@@ -1711,11 +1711,6 @@ bool HostConnector::replaceBlock(const uint8_t row,
                 hostBypassBlockPair(hbp, false);
             }
 
-            if (! params.empty())
-            {
-                hostPrerunBlockPair(hbp, LV2_KXSTUDIO_PROPERTIES_RESET_FULL, params);
-            }
-
             for (uint8_t p = 0, size = blockdata.properties.size(); p < size; ++p)
             {
                 Property& propdata(blockdata.properties[p]);
@@ -1727,6 +1722,9 @@ bool HostConnector::replaceBlock(const uint8_t row,
                 if (propsToReset[p])
                     hostPatchSetBlockPair(hbp, propdata);
             }
+
+            if (! params.empty())
+                hostPrerunBlockPair(hbp, LV2_KXSTUDIO_PROPERTIES_RESET_FULL, params);
         }
 
         return true;
@@ -1794,7 +1792,7 @@ bool HostConnector::replaceBlock(const uint8_t row,
 
         HostBlockPair hbp = { _mapper.add(_current.preset, row, block), kMaxHostInstances };
 
-        bool added = _host.preload(uri, hbp.id);
+        bool added = _host.add(uri, hbp.id);
         if (added)
         {
             mod_log_debug("block %u loaded plugin %s", block, uri);
@@ -1825,9 +1823,7 @@ bool HostConnector::replaceBlock(const uint8_t row,
                 blockdata.meta.numSideOutputs = numSideOutputs;
 
                 if (!blockdata.enabled)
-                {
-                    hostBypassBlockPair(hbp, true);
-                }
+                    _host.bypass(hbp.id, true);
 
                 // TODO: check if also needed for regular replace case
                 // previously used only in replaceBlockWhileKeepingData
@@ -1839,7 +1835,7 @@ bool HostConnector::replaceBlock(const uint8_t row,
                         continue;
 
                     if (propdata.value != propdata.meta.defpath)
-                        hostPatchSetBlockPair(hbp, propdata);
+                        _host.patch_set(hbp.id, propdata.uri.c_str(), propdata.value.c_str());
                 }
             }
             else
@@ -1863,18 +1859,7 @@ bool HostConnector::replaceBlock(const uint8_t row,
                     paramdata.meta.state = Lv2ParameterStateNone;
             }
 
-            hostPrerunBlockPair(hbp, LV2_KXSTUDIO_PROPERTIES_RESET_FULL, params);
-
-            // activate block pair
-            if (hbp.pair != kMaxHostInstances)
-            {
-                const int16_t instances[2] = { static_cast<int16_t>(hbp.id), static_cast<int16_t>(hbp.pair) };
-                _host.multi_activate(true, 2, instances);
-            }
-            else
-            {
-                _host.activate(hbp.id, true);
-            }
+            _host.pre_run(hbp.id, LV2_KXSTUDIO_PROPERTIES_RESET_FULL, params.size(), params.data());
 
             hostSetupSideIO(_current.preset, row, block, hbp);
         }
@@ -2150,11 +2135,6 @@ bool HostConnector::resetBlock(const uint8_t row, const uint8_t block, const boo
 
     const Host::NonBlockingScopeWithAudioFades hnbs(_host);
 
-    if (! params.empty())
-    {
-        hostPrerunBlockPair(hbp, LV2_KXSTUDIO_PROPERTIES_RESET_FULL, params);
-    }
-
     for (uint8_t p = 0, size = blockdata.properties.size(); p < size; ++p)
     {
         Property& propdata(blockdata.properties[p]);
@@ -2166,6 +2146,9 @@ bool HostConnector::resetBlock(const uint8_t row, const uint8_t block, const boo
         if (propsToReset[p])
             hostPatchSetBlockPair(hbp, propdata);
     }
+
+    if (! params.empty())
+        hostPrerunBlockPair(hbp, LV2_KXSTUDIO_PROPERTIES_RESET_FULL, params);
 
     return true;
 }


### PR DESCRIPTION
When `replaceBlock()` is used for adding new blocks they are preloaded (which means they begin deactivated) and shortly after pre-run is called. The pre-run needs the plugin to be active first, which means:
1. plugin is loaded
2. plugin is activated (for pre-run)
3. pre-run happens
4. plugin is deactivated (for pre-run to keep old state)
5. plugin is finally activated

This seems unnecessary, as we already disabled processing globally with the audio-fade non-blocking scope.

Extras for this PR:
- Make sure params are changed after properties, for consistency
- Replace block-pair calls with single host calls during `replaceBlock()` as it always only happens with the 1st instance so checking for block-pair is not only useless but misleading for readers.
